### PR TITLE
Link mediable to possibly custom object based on the config value.

### DIFF
--- a/src/Mediable.php
+++ b/src/Mediable.php
@@ -28,7 +28,7 @@ trait Mediable
      */
     public function media()
     {
-        return $this->morphToMany(Media::class, 'mediable')->withPivot('tag');
+        return $this->morphToMany(config('mediable.model'), 'mediable')->withPivot('tag');
     }
 
     /**


### PR DESCRIPTION
I'm using a custom class for Media, as my id property generates UUID v4 values instead of unsigned integer.

The issue is, Mediable is still attached to the original `\Plank\Mediable\Media` via its `media()` method, instead of using my class that extends it.

A solution is using defined earlier config variable to connect it with my class.