### PR TITLE
Use url config value to generate disk url

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -105,6 +105,42 @@ If you are using symbolic links to make local disks accessible, you can instruct
 
     $media->getUrl(); // returns http://domain.com/assets/foo.jpg
 
+Whether you are using symbolic links or not, you can set the ``'url'`` config value to generate disk urls on another domain. Note that you can specify any path in the url, as the root path doesn't have to match, as long as you have set up your web server accordingly.
+
+::
+
+    <?php
+    'disks' => [
+        'uploads' => [
+            'driver' => 'local',
+            'root' => public_path('uploads'),
+            'url' => 'http://example.com/assets',
+        ],
+    ]
+
+    //...
+
+    $media->getUrl(); // returns http://example.com/assets/foo.jpg
+
+However, if you are using a symbolic link to make a local disk accessible, the prefix will be appended to the disk url.
+
+::
+
+    <?php
+    'disks' => [
+        'public' => [
+            'driver' => 'local',
+            'root' => storage_path('public'),
+            'visibility' => 'public',
+            'prefix' => 'assets',
+            'url' => 'http://example.com',
+        ],
+    ]
+
+    //...
+
+    $media->getUrl(); // returns http://example.com/assets/foo.jpg
+
 
 Permissions for S3-based disks is set on the buckets themselves. You can inform the package that ``Media`` on an S3 disk can be linked by URL by adding the ``'visibility' => 'public'`` key to the disk config.
 

--- a/src/UrlGenerators/LocalUrlGenerator.php
+++ b/src/UrlGenerators/LocalUrlGenerator.php
@@ -62,7 +62,19 @@ class LocalUrlGenerator extends BaseUrlGenerator
      */
     public function getUrl()
     {
-        return $this->url->asset($this->getPublicPath());
+        $path = $this->getPublicPath();
+
+        $url = $this->getDiskConfig('url');
+
+        if ($url) {
+            if ($this->isInWebroot()) {
+                $path = $this->media->getDiskPath();
+            }
+
+            return rtrim($url, '/').'/'.trim($path, '/');
+        }
+
+        return $this->url->asset($path);
     }
 
     /**

--- a/tests/integration/MediaTest.php
+++ b/tests/integration/MediaTest.php
@@ -127,6 +127,13 @@ class MediaTest extends TestCase
         $this->assertEquals('http://localhost/uploads/foo/bar/baz.jpg', $media->getUrl());
     }
 
+    public function test_it_can_generate_a_custom_url_to_the_local_file()
+    {
+        $this->app['config']->set('filesystems.disks.uploads.url', 'http://example.com');
+        $media = factory(Media::class)->make(['disk' => 'uploads', 'directory' => 'foo/bar', 'filename' => 'baz', 'extension' => 'jpg']);
+        $this->assertEquals('http://example.com/foo/bar/baz.jpg', $media->getUrl());
+    }
+
     public function test_it_can_generate_a_url_to_the_file_on_s3()
     {
         if (!$this->s3ConfigLoaded()) {

--- a/tests/integration/UrlGenerators/LocalUrlGeneratorTest.php
+++ b/tests/integration/UrlGenerators/LocalUrlGeneratorTest.php
@@ -20,6 +20,20 @@ class LocalUrlGeneratorTest extends TestCase
         $this->assertEquals('http://localhost/uploads/foo/bar.jpg', $generator->getUrl());
     }
 
+    public function test_it_generates_custom_url()
+    {
+        $this->app['config']->set('filesystems.disks.uploads.url', 'http://example.com');
+        $generator = $this->setupGenerator();
+        $this->assertEquals('http://example.com/foo/bar.jpg', $generator->getUrl());
+    }
+
+    public function test_it_generates_prefixed_custom_url()
+    {
+        $this->app['config']->set('filesystems.disks.public_storage.url', 'http://example.com');
+        $generator = $this->setupGenerator('public_storage');
+        $this->assertEquals('http://example.com/prefix/foo/bar.jpg', $generator->getUrl());
+    }
+
     public function test_it_throws_exception_for_non_public_disk()
     {
         $generator = $this->setupGenerator('tmp');


### PR DESCRIPTION
Add the ability to set a custom url for a disk.
This feature has landed on laravel 5.3, and this commit allows to use
it on any compatible version.

See https://github.com/laravel/framework/pull/16281 for details and use
cases.