### PR TITLE
Ability to get last media item

### DIFF
--- a/docs/source/mediable.rst
+++ b/docs/source/mediable.rst
@@ -72,7 +72,7 @@ You can retrieve media attached to a file by referring to the tag to which it wa
     <?php
     $media = $post->getMedia('thumbnail');
 
-This returns a collection of all media assigned to that tag. In cases where you only need one ``Media`` entity, you can instead use ``firstMedia()``.
+This returns a collection of all media assigned to that tag. In cases where you only need one ``Media`` entity, you can instead use ``firstMedia()`` or ``lastMedia()``.
 
 ::
 
@@ -247,7 +247,7 @@ Automatic Rehydration
 
 By default, ``Mediable`` models will automatically reload their media relationship the next time the media at a given tag is accessed after that tag is modified.
 
-The ``attachMedia()``, ``syncMedia()``, ``detachMedia()``, and ``detachMediaTags()`` methods will mark any tags passed as being dirty, while the ``hasMedia()`` ``getMedia()``, ``firstMedia()``, ``getAllMediaByTag()``, and ``getTagsForMedia()`` methods will execute ``loadMedia()`` to reload all media if they attempt to read a dirty tag.
+The ``attachMedia()``, ``syncMedia()``, ``detachMedia()``, and ``detachMediaTags()`` methods will mark any tags passed as being dirty, while the ``hasMedia()`` ``getMedia()``, ``firstMedia()``, ``lastMedia()``, ``getAllMediaByTag()``, and ``getTagsForMedia()`` methods will execute ``loadMedia()`` to reload all media if they attempt to read a dirty tag.
 
 For example:
 

--- a/src/Mediable.php
+++ b/src/Mediable.php
@@ -296,7 +296,7 @@ trait Mediable
     }
 
     /**
-     * Shorthand for retrieving a single attached media.
+     * Shorthand for retrieving the first attached media item.
      * @param  string|array  $tags
      * @param  bool         $match_all
      * @see \Plank\Mediable\Mediable::getMedia()
@@ -305,6 +305,18 @@ trait Mediable
     public function firstMedia($tags, $match_all = false)
     {
         return $this->getMedia($tags, $match_all)->first();
+    }
+
+    /**
+     * Shorthand for retrieving the last attached media item.
+     * @param  string|array  $tags
+     * @param  bool         $match_all
+     * @see \Plank\Mediable\Mediable::getMedia()
+     * @return bool
+     */
+    public function lastMedia($tags, $match_all = false)
+    {
+        return $this->getMedia($tags, $match_all)->last();
     }
 
     /**

--- a/tests/integration/MediableTest.php
+++ b/tests/integration/MediableTest.php
@@ -61,6 +61,18 @@ class MediableTest extends TestCase
         $this->assertEquals(1, $mediable->firstMedia('foo')->id);
     }
 
+    public function test_it_can_find_the_last_media()
+    {
+        $mediable = factory(SampleMediable::class)->create();
+        $media1 = factory(Media::class)->create(['id' => 1]);
+        $media2 = factory(Media::class)->create(['id' => 2]);
+
+        $mediable->attachMedia($media1, 'foo');
+        $mediable->attachMedia($media2, 'foo');
+
+        $this->assertEquals(2, $mediable->lastMedia('foo')->id);
+    }
+
     public function test_it_can_find_media_matching_any_tags()
     {
         $mediable = factory(SampleMediable::class)->create();


### PR DESCRIPTION
I've named this function `latestMedia`, but maybe `lastMedia` would be more consistent. Let me know if you want the name changed (or anything else changed).

I've not added docs, but I'll do that if it gets accepted.