### PR TITLE
adds on_duplicate_update

### DIFF
--- a/docs/source/uploader.rst
+++ b/docs/source/uploader.rst
@@ -76,11 +76,14 @@ Occasionally, a file with a matching name might already exist at the destination
 ::
 
     <?php
-
+    
     // keep both, append incrementing counter to new file name
     $uploader->onDuplicateIncrement();
 
-    // replace old file with new one
+    // replace old file with new one, update existing Media record
+    $uploader->onDuplicateUpdate();
+
+    // replace old file and media record with new ones
     $uploader->onDuplicateReplace();
 
     // cancel upload, throw an exception

--- a/src/MediaUploader.php
+++ b/src/MediaUploader.php
@@ -676,7 +676,7 @@ class MediaUploader
                 case static::ON_DUPLICATE_UPDATE:
                     $this->deleteExistingFile($model);
                     $model->{$model->getKeyName()} = Media::forPathOnDisk(
-                        $model->disk,$model->getDiskPath())
+                        $model->disk, $model->getDiskPath())
                         ->pluck($model->getKeyName())->first();
                     $model->exists = true;
                     break;

--- a/src/MediaUploader.php
+++ b/src/MediaUploader.php
@@ -676,6 +676,7 @@ class MediaUploader
                 case static::ON_DUPLICATE_UPDATE:
                     $this->deleteExistingFile($model);
                     $model = $this->findExistingMediaRecord($model);
+                    $model->exists = true;
                     $model->touch();
                     break;
                 case static::ON_DUPLICATE_INCREMENT:

--- a/src/MediaUploader.php
+++ b/src/MediaUploader.php
@@ -675,7 +675,7 @@ class MediaUploader
                     break;
                 case static::ON_DUPLICATE_UPDATE:
                     $this->deleteExistingFile($model);
-                    $model = $this->findExistingMediaRecord($model);
+                    $model = Media::forPathOnDisk($model->disk, $model->getDiskPath())->first();
                     $model->exists = true;
                     $model->touch();
                     break;
@@ -701,23 +701,6 @@ class MediaUploader
             ->delete();
 
         $this->deleteExistingFile($model);
-    }
-
-    /**
-     * Find the media that previously existed at a destination.
-     * @param  \Plank\Mediable\Media  $model
-     * @return \Plank\Mediable\Media  $model
-     */
-    private function findExistingMediaRecord(Media $model)
-    {
-        if ($model->exists) {
-            return $model;
-        }
-        return Media::where('disk', $model->disk)
-            ->where('directory', $model->directory)
-            ->where('filename', $model->filename)
-            ->where('extension', $model->extension)
-            ->first();
     }
 
     /**

--- a/src/MediaUploader.php
+++ b/src/MediaUploader.php
@@ -626,7 +626,7 @@ class MediaUploader
      */
     private function handleDuplicate(Media $model)
     {
-        if($this->filesystem->disk($model->disk)->has($model->getDiskPath())) {
+        if ($this->filesystem->disk($model->disk)->has($model->getDiskPath())) {
 
             switch ($this->config['on_duplicate']) {
                 case static::ON_DUPLICATE_ERROR:
@@ -671,8 +671,9 @@ class MediaUploader
      */
     private function findExistingMediaRecord(Media $model)
     {
-        if($model->exists)
+        if ($model->exists) {
             return $model;
+        }
         return Media::where('disk', $model->disk)
             ->where('directory', $model->directory)
             ->where('filename', $model->filename)

--- a/src/MediaUploader.php
+++ b/src/MediaUploader.php
@@ -675,9 +675,10 @@ class MediaUploader
                     break;
                 case static::ON_DUPLICATE_UPDATE:
                     $this->deleteExistingFile($model);
-                    $model = Media::forPathOnDisk($model->disk, $model->getDiskPath())->first();
+                    $model->{$model->getKeyName()} = Media::forPathOnDisk(
+                        $model->disk,$model->getDiskPath())
+                        ->pluck($model->getKeyName())->first();
                     $model->exists = true;
-                    $model->touch();
                     break;
                 case static::ON_DUPLICATE_INCREMENT:
                 default:

--- a/src/MediaUploader.php
+++ b/src/MediaUploader.php
@@ -627,7 +627,6 @@ class MediaUploader
     private function handleDuplicate(Media $model)
     {
         if ($this->filesystem->disk($model->disk)->has($model->getDiskPath())) {
-
             switch ($this->config['on_duplicate']) {
                 case static::ON_DUPLICATE_ERROR:
                     throw FileExistsException::fileExists($model->getDiskPath());

--- a/tests/integration/MediaUploaderTest.php
+++ b/tests/integration/MediaUploaderTest.php
@@ -252,8 +252,8 @@ class MediaUploaderTest extends TestCase
 
         $this->seedFileForMedia($media, fopen(__DIR__ . '/../_data/plank.png', 'r'));
 
-        $ca = $media->created_at;
-        $ua = $media->updated_at;
+        $creaetdAt = $media->created_at;
+        $updatedAt = $media->updated_at;
         sleep(1); // required to check the update time is different
 
         $result = Facade::fromSource(__DIR__ . '/../_data/plank.png')
@@ -261,8 +261,8 @@ class MediaUploaderTest extends TestCase
             ->toDestination('tmp', '')->upload();
 
         $media = $media->fresh();
-        $this->assertEquals($media->created_at, $ca);
-        $this->assertNotEquals($media->updated_at, $ua);
+        $this->assertEquals($media->created_at, $creaetdAt);
+        $this->assertNotEquals($media->updated_at, $updatedAt);
         $this->assertEquals($media->getKey(), $result->getKey());
         $this->assertEquals('image', $media->aggregate_type);
     }

--- a/tests/integration/MediaUploaderTest.php
+++ b/tests/integration/MediaUploaderTest.php
@@ -262,10 +262,12 @@ class MediaUploaderTest extends TestCase
 
         $this->assertFalse($m2->exists);
         $this->assertTrue($m1->exists);
+        sleep(1); // required to check the update time is different
         $m2 = $method->invoke($uploader, $m2);
         $this->assertTrue($m2->exists);
-        $this->assertEquals($m1->created_at, $m2->created_at);
         $this->assertEquals($m1->id, $m2->id);
+        $this->assertEquals($m1->created_at, $m2->created_at);
+        $this->assertNotEquals($m1->updated_at, $m2->updated_at);
         $this->assertTrue($m2->save()); // check it does not throw an exception
     }
 


### PR DESCRIPTION
I thought I'd try to implement #67 as part of hacktoberfest, but I'm not overly happy with it. Any feedback you have would be great.

### List of changes:
* Added MediaUploader::ON_DUPLICATE_UPDATE + a set method for it.

* Removed `verifyDestination` function. I found this function to be confusing as it appears to only check if the file exists and then calls `handleDuplicate`. However, handleDuplicate should always check if a file exists before doing anything, so I moved the check into the `handDuplicate` function and removed `verifyDestination`. As this was a private function, it should not break anyone's code (this was also updated in the `MediaUploaderTest`).

* Modified `handleDuplicate` to now return a Media model. If ON_DUPLICATE_UPDATE is set, it returns the model from the database, else it returns the input parameter `$model`.

* Added ON_DUPLICATE_UPDATE case in the `handleDuplicate` method which deletes the existing file on disk, then finds the existing media and updates the `updated_at` timestamp. This has to be done as the model is not dirty and thus does not actually save when `$media->save()` is called.

* Added `test_it_can_update_duplicate_files` to test it actually works.

* Added a function similar to `deleteExistingMedia` called `deleteExistingFile` which only deletes the file on disk, rather than the actual Media database record. As this function has the ability to knock the database and file system out of sync, I made it a private function.

* Last but not least, I added a function named `findExistingMediaRecord` to find existing media records which point to a position on disk that we are trying to use.

### Docs
I'll update the docs once I know whether you want this merged or not.