### PR TITLE
Skip deleted media if not detached

### DIFF
--- a/src/Mediable.php
+++ b/src/Mediable.php
@@ -43,9 +43,16 @@ trait Mediable
      */
     public function media()
     {
-        return $this->morphToMany(config('mediable.model'), 'mediable')
-            ->withPivot('tag', 'order')
-            ->orderBy('order');
+        $media = $this->morphToMany(config('mediable.model'), 'mediable')
+                    ->withPivot('tag', 'order')
+                    ->orderBy('order');
+
+        // Skip deleted media if not detached
+        if (config('mediable.detach_on_soft_delete') == false) {
+            $media->whereNull('deleted_at');
+        }
+
+        return $media;
     }
 
     /**


### PR DESCRIPTION
Currently, if you don't detach the deleted media, will return the it which is not wanted for soft delete.