### PR TITLE
copyFrom Function

### DIFF
--- a/docs/source/media.rst
+++ b/docs/source/media.rst
@@ -76,7 +76,9 @@ You can change the location of a media file on disk. You cannot move a media to 
 Copying Media
 ---------------------
 
-You can copy the associated media file to another one by using the ``copyFrom()`` method. This will also save the new model where this media file is associated.
+You can copy the associated media file to another one by using the ``copyTo()`` method. You can also specify a new filename when copying the file to another location.
+
+This method will also create a new model where the copied file is associated.
 
 ::
 
@@ -84,8 +86,8 @@ You can copy the associated media file to another one by using the ``copyFrom()`
     // we assume you already have a $media!
 
     // copy a media entry
-    $newMedia = $media->replicate();
-    $newMedia->copyFrom($media, 'new/destination', 'newFilename');
+    $newMedia = $media->copyTo('new/directory');
+    $newMedia = $media->copyTo('new/directory', 'new-filename');
 
 Deleting Media
 ---------------------

--- a/docs/source/media.rst
+++ b/docs/source/media.rst
@@ -73,6 +73,19 @@ You can change the location of a media file on disk. You cannot move a media to 
 	$media->move('new/directory', 'new-filename');
 	$media->rename('new-filename');
 
+Copying Media
+---------------------
+
+You can copy the associated media file to another one by using the ``copyFrom()`` method. This will also save the new model where this media file is associated.
+
+::
+
+    <?php
+    // we assume you already have a $media!
+
+    // copy a media entry
+    $newMedia = $media->replicate();
+    $newMedia->copyFrom($media, 'new/destination', 'newFilename');
 
 Deleting Media
 ---------------------

--- a/docs/source/media.rst
+++ b/docs/source/media.rst
@@ -62,7 +62,7 @@ If you need to query the media table directly, rather than through associated mo
 Moving Media
 ---------------------
 
-You should taking caution if manually changing a media record's attributes, as you record and file could go out of sync.
+You should taking caution if manually changing a media record's attributes, as your record and file could go out of sync.
 
 You can change the location of a media file on disk. You cannot move a media to a different disk this way.
 
@@ -76,16 +76,11 @@ You can change the location of a media file on disk. You cannot move a media to 
 Copying Media
 ---------------------
 
-You can copy the associated media file to another one by using the ``copyTo()`` method. You can also specify a new filename when copying the file to another location.
-
-This method will also create a new model where the copied file is associated.
+You can duplicate a media file to a different location on disk with the ``copyTo()`` method. Doing so will create a new `Media` record for the new file. If a filename is not provided, the new file will copy the original filename. 
 
 ::
 
     <?php
-    // we assume you already have a $media!
-
-    // copy a media entry
     $newMedia = $media->copyTo('new/directory');
     $newMedia = $media->copyTo('new/directory', 'new-filename');
 

--- a/src/Exceptions/MediaMoveException.php
+++ b/src/Exceptions/MediaMoveException.php
@@ -13,4 +13,9 @@ class MediaMoveException extends Exception
     {
         return new static("Another file already exists at `{$path}`");
     }
+
+    public static function failedToCopy($from, $to)
+    {
+        return new static("Failed to copy file from `{$from}` to `{$to}`.");
+    }
 }

--- a/src/Media.php
+++ b/src/Media.php
@@ -210,6 +210,20 @@ class Media extends Model
     }
 
     /**
+     * Copy the file from one Media object to another one.
+     *
+     * Will invoke the `save()` method on the model after the associated file has been copied to prevent synchronization errors
+     * @param  \Plank\Mediable\Media $mediaFrom   the media the file is copied from
+     * @param  string                $destination directory relative to disk root
+     * @param  string                $filename    optional filename. Do not include extension
+     * @return void
+     */
+    public function copyFrom($mediaFrom, $destination, $filename = null)
+    {
+        app('mediable.mover')->copyFrom($this, $mediaFrom, $destination, $filename);
+    }
+
+    /**
      * Rename the file in place.
      * @param  string $name
      * @return void

--- a/src/Media.php
+++ b/src/Media.php
@@ -213,14 +213,13 @@ class Media extends Model
      * Copy the file from one Media object to another one.
      *
      * Will invoke the `save()` method on the model after the associated file has been copied to prevent synchronization errors
-     * @param  \Plank\Mediable\Media $mediaFrom   the media the file is copied from
-     * @param  string                $destination directory relative to disk root
-     * @param  string                $filename    optional filename. Do not include extension
-     * @return void
+     * @param  string $destination directory relative to disk root
+     * @param  string $filename    optional filename. Do not include extension
+     * @return \Plank\Mediable\Media
      */
-    public function copyFrom($mediaFrom, $destination, $filename = null)
+    public function copyTo($destination, $filename = null)
     {
-        app('mediable.mover')->copyFrom($this, $mediaFrom, $destination, $filename);
+        return app('mediable.mover')->copyTo($this, $destination, $filename);
     }
 
     /**

--- a/src/MediaMover.php
+++ b/src/MediaMover.php
@@ -32,7 +32,7 @@ class MediaMover
      * Will invoke the `save()` method on the model after the associated file has been moved to prevent synchronization errors
      * @param  \Plank\Mediable\Media $media
      * @param  string                $directory directory relative to disk root
-     * @param  string                $name      filename. Do not include extension
+     * @param  string                $filename  filename. Do not include extension
      * @return void
      * @throws \Plank\Mediable\Exceptions\MediaMoveException If attempting to change the file extension or a file with the same name already exists at the destination
      */
@@ -55,6 +55,44 @@ class MediaMover
 
         $storage->move($media->getDiskPath(), $target_path);
 
+        $media->filename = $filename;
+        $media->directory = $directory;
+        $media->save();
+    }
+
+    /**
+     * Copy the file from one Media object to another one.
+     *
+     * Will invoke the `save()` method on the model after the associated file has been copied to prevent synchronization errors
+     *
+     * @param  \Plank\Mediable\Media $media
+     * @param  \Plank\Mediable\Media $mediaFrom   the media the file is copied from
+     * @param  string                $destination directory relative to disk root
+     * @param  string                $filename    optional filename. Do not include extension
+     * @return void
+     * @throws \Plank\Mediable\Exceptions\MediaMoveException If attempting to change the file extension or a file with the same name already exists at the destination
+     */
+    public function copyFrom(Media $media, Media $mediaFrom, $destination, $filename = null)
+    {
+        $storageFrom = $this->filesystem->disk($mediaFrom->disk);
+        $storageTo = $this->filesystem->disk($media->disk);
+
+        if ($filename) {
+            $filename = $this->removeExtensionFromFilename($filename, $media->extension);
+        } else {
+            $filename = $media->filename;
+        }
+
+        $directory = trim($destination, '/');
+        $target_path = $directory.'/'.$filename.'.'.$media->extension;
+
+        if ($storageTo->has($target_path)) {
+            throw MediaMoveException::destinationExists($target_path);
+        }
+
+        $storageFrom->copy($mediaFrom->getDiskPath(), $target_path);
+
+        // copy the media and set the new values
         $media->filename = $filename;
         $media->directory = $directory;
         $media->save();

--- a/tests/integration/MediaTest.php
+++ b/tests/integration/MediaTest.php
@@ -176,19 +176,23 @@ class MediaTest extends TestCase
         $media = factory(Media::class)->make(['disk' => 'tmp', 'directory' => 'foo', 'filename' => 'bar', 'extension' => 'baz']);
         $this->seedFileForMedia($media);
 
-        // create a new media based on the default one
-        $copiedMedia = $media->replicate();
-        $copiedMedia->filename = 'foo';
-        $copiedMedia->save();
-
         // copy the file and make some checks
-        $copiedMedia->copyFrom($media, 'alpha');
-        $this->assertEquals('alpha/foo.baz', $copiedMedia->getDiskPath());
-        $this->assertTrue($copiedMedia->exists());
+        $copiedMedia1 = $media->copyTo('alpha', 'test');
+        $this->assertEquals('alpha/test.baz', $copiedMedia1->getDiskPath());
+        $this->assertTrue($copiedMedia1->exists());
 
         // check that the "old" media file still exists
         $this->assertEquals('foo/bar.baz', $media->getDiskPath());
         $this->assertTrue($media->exists());
+
+        // check, if it works without a filename (the filename of the original media object is used!)
+        $copiedMedia2 = $media->copyTo('beta');
+        $this->assertEquals('beta/bar.baz', $copiedMedia2->getDiskPath());
+        $this->assertTrue($copiedMedia2->exists());
+
+        // check if it throws an exception if the file already exists
+        $this->expectException(MediaMoveException::class);
+        $copiedMedia3 = $media->copyTo('alpha', 'test');
     }
 
     public function test_it_throws_an_exception_if_moving_to_existing_file()

--- a/tests/integration/MediaTest.php
+++ b/tests/integration/MediaTest.php
@@ -168,6 +168,29 @@ class MediaTest extends TestCase
         $this->assertTrue($media->exists());
     }
 
+    public function test_it_can_be_copied_on_disk()
+    {
+        $this->useFilesystem('tmp');
+        $this->useDatabase();
+
+        $media = factory(Media::class)->make(['disk' => 'tmp', 'directory' => 'foo', 'filename' => 'bar', 'extension' => 'baz']);
+        $this->seedFileForMedia($media);
+
+        // create a new media based on the default one
+        $copiedMedia = $media->replicate();
+        $copiedMedia->filename = 'foo';
+        $copiedMedia->save();
+
+        // copy the file and make some checks
+        $copiedMedia->copyFrom($media, 'alpha');
+        $this->assertEquals('alpha/foo.baz', $copiedMedia->getDiskPath());
+        $this->assertTrue($copiedMedia->exists());
+
+        // check that the "old" media file still exists
+        $this->assertEquals('foo/bar.baz', $media->getDiskPath());
+        $this->assertTrue($media->exists());
+    }
+
     public function test_it_throws_an_exception_if_moving_to_existing_file()
     {
         $this->useFilesystem('tmp');


### PR DESCRIPTION
This PR adds a new `copyFrom()` function to the `Media` object.

The function behaves like this:
It copies the associated file on the disk and assigns it to a `Media` object.

For example:
```
// lets assume we have a $media object

// now create a new media file
$newMedia = $media->replicate();
$newMedia->copyFrom($media, 'new/directory', 'filename');
```

This `copyFrom()` will, thereby, copy the file on the disk to `/new/directory` and update the `$newMedia`to reflect these changes.

I have already added a test for this scenario