### PR TITLE
Ensure neater filenames in case of duplicates

### DIFF
--- a/src/MediaUploader.php
+++ b/src/MediaUploader.php
@@ -668,9 +668,12 @@ class MediaUploader
         $storage = $this->filesystem->disk($model->disk);
         $counter = 0;
         do {
-            ++$counter;
-            $filename = "{$model->filename} ({$counter})";
+            $filename = "{$model->filename}";
+            if ($counter > 0) {
+                $filename .= '-' . $counter;
+            }
             $path = "{$model->directory}/{$filename}.{$model->extension}";
+            ++$counter;
         } while ($storage->has($path));
 
         return $filename;

--- a/tests/integration/MediaUploaderTest.php
+++ b/tests/integration/MediaUploaderTest.php
@@ -252,7 +252,7 @@ class MediaUploaderTest extends TestCase
 
         $method->invoke($uploader, $media);
 
-        $this->assertEquals('plank (2)', $media->filename);
+        $this->assertEquals('plank-1', $media->filename);
     }
 
     public function test_it_uploads_files()


### PR DESCRIPTION
I wanted to ensure that the filename was as neat as possible in the case of duplicates. 

I have not created a test covering this yet, I'm just wondering, really if it's something that would be considered, and figured the best way of finding out would be via a PR.

In the case of duplicates, instead of 
* some-file (1).png

save a file like 
* some-file-1.png