### PR TITLE
Fix URL generation for local disks using symbolic links

### DIFF
--- a/src/UrlGenerators/LocalUrlGenerator.php
+++ b/src/UrlGenerators/LocalUrlGenerator.php
@@ -50,7 +50,7 @@ class LocalUrlGenerator extends BaseUrlGenerator
         if ($this->isInWebroot()) {
             $path = str_replace(public_path(), '', $this->getAbsolutePath());
         } else {
-            $path = rtrim($this->getDiskConfig('prefix', 'storage'), '/').'/'.$this->media->getDiskPath();
+            $path = rtrim($this->getPrefix(), '/').'/'.$this->media->getDiskPath();
         }
 
         return $this->cleanDirectorySeparators($path);
@@ -102,5 +102,27 @@ class LocalUrlGenerator extends BaseUrlGenerator
     private function isInWebroot()
     {
         return strpos($this->getAbsolutePath(), public_path()) === 0;
+    }
+
+    /**
+     * Get the prefix.
+     *
+     * If the prefix and the url are not set, we will assume the prefix
+     * is "storage", in order to point to the default symbolink link.
+     *
+     * Otherwise, we will trust the user has correctly set the prefix and/or the url.
+     *
+     * @return string
+     */
+    private function getPrefix()
+    {
+        $prefix = $this->getDiskConfig('prefix', '');
+        $url = $this->getDiskConfig('url');
+
+        if (! $prefix && ! $url) {
+            return 'storage';
+        }
+
+        return $prefix;
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -57,8 +57,8 @@ class TestCase extends BaseTestCase
             'public_storage' => [
                 'driver' => 'local',
                 'root' => storage_path('public'),
+                'url' => 'http://localhost/storage',
                 'visibility' => 'public',
-                'prefix' => 'prefix'
             ],
             's3' => [
                 'driver' => 's3',

--- a/tests/integration/UrlGenerators/LocalUrlGeneratorTest.php
+++ b/tests/integration/UrlGenerators/LocalUrlGeneratorTest.php
@@ -27,11 +27,19 @@ class LocalUrlGeneratorTest extends TestCase
         $this->assertEquals('http://example.com/foo/bar.jpg', $generator->getUrl());
     }
 
+    public function test_it_generates_prefixed_url()
+    {
+        $this->app['config']->set('filesystems.disks.public_storage.url', null);
+        $this->app['config']->set('filesystems.disks.public_storage.prefix', 'uploads');
+        $generator = $this->setupGenerator('public_storage');
+        $this->assertEquals('http://localhost/uploads/foo/bar.jpg', $generator->getUrl());
+    }
+
     public function test_it_generates_prefixed_custom_url()
     {
-        $this->app['config']->set('filesystems.disks.public_storage.url', 'http://example.com');
+        $this->app['config']->set('filesystems.disks.public_storage.prefix', 'uploads');
         $generator = $this->setupGenerator('public_storage');
-        $this->assertEquals('http://example.com/prefix/foo/bar.jpg', $generator->getUrl());
+        $this->assertEquals('http://localhost/storage/uploads/foo/bar.jpg', $generator->getUrl());
     }
 
     public function test_it_throws_exception_for_non_public_disk()
@@ -41,10 +49,10 @@ class LocalUrlGeneratorTest extends TestCase
         $generator->getPublicPath();
     }
 
-    public function test_it_accepts_public_visiblity()
+    public function test_it_accepts_public_visibility()
     {
         $generator = $this->setupGenerator('public_storage');
-        $this->assertEquals('http://localhost/prefix/foo/bar.jpg', $generator->getUrl());
+        $this->assertEquals('http://localhost/storage/foo/bar.jpg', $generator->getUrl());
     }
 
     protected function setupGenerator($disk = 'uploads')


### PR DESCRIPTION
Since Laravel 5.4, the filesystems.php includes the `storage` prefix in the `url` for the `public` disk, which causes the `LocalUrlGenerator` to produce URLs like `http://localhost/storage/storage/foo/bar.jpg`, because this class used `storage` as the default prefix.

Before 5.4, the `prefix` and the `url` were not set by default, so the default `storage` prefix was needed to point to the symbolic link.

This PR addresses this issue for all versions, maintaining BC, by checking if the disk configuration has a `prefix` or a `url` set, otherwise it uses `storage` as the default prefix.