### PR TITLE
Remapped Duplicate behaviour

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -5,8 +5,6 @@
 Minimum PHP version moved to 7.0
 Minimum Laravel version moved to 5.3
 
-The behaviour of `MediaUploader::onDuplicateReplace()` method has been changed to preserve the original `Media` record and any attachments. The old behaviour has been renamed to `MediaUploader::onDuplicateDelete()`.
-
 ## 1.x to 2.x
 
 You need to add an order column to the mediables table.

--- a/config/mediable.php
+++ b/config/mediable.php
@@ -34,6 +34,7 @@ return [
      *
      * * `'increment'`: the new file's name is given an incrementing suffix
      * * `'replace'` : the old file and media model is deleted
+     * * `'update'` : the old file is replaced, but the media record is updated
      * * `'error'`: an Exception is thrown
      */
     'on_duplicate' => Plank\Mediable\MediaUploader::ON_DUPLICATE_INCREMENT,

--- a/docs/build/html/_sources/configuration.txt
+++ b/docs/build/html/_sources/configuration.txt
@@ -149,6 +149,7 @@ The `config/mediable.php` offers a number of options for configuring how media u
      *
      * * 'increment': the new file's name is given an incrementing suffix
      * * 'replace' : the old file and media model is deleted
+     * * 'update' : the old file is replaced, but the media record is updated
      * * 'error': an Exception is thrown
      *
      */

--- a/docs/build/html/configuration.html
+++ b/docs/build/html/configuration.html
@@ -268,6 +268,7 @@
 <span class="cm"> *</span>
 <span class="cm"> * * &#39;increment&#39;: the new file&#39;s name is given an incrementing suffix</span>
 <span class="cm"> * * &#39;replace&#39; : the old file and media model is deleted</span>
+<span class="cm"> * * &#39;update&#39; : the old file is replaced, but the media record is updated</span>
 <span class="cm"> * * &#39;error&#39;: an Exception is thrown</span>
 <span class="cm"> *</span>
 <span class="cm"> */</span>

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -186,6 +186,7 @@ The `config/mediable.php` offers a number of options for configuring how media u
      *
      * * 'increment': the new file's name is given an incrementing suffix
      * * 'replace' : the old file and media model is deleted
+     * * 'update' : the old file is replaced, but the media model is updated
      * * 'error': an Exception is thrown
      *
      */

--- a/docs/source/uploader.rst
+++ b/docs/source/uploader.rst
@@ -71,7 +71,7 @@ You can restore the default behaviour with ``useOriginalFilename()``.
 Handling Duplicates
 ----------------------
 
-Occasionally, a file with a matching name might already exist at the destination you would like to upload to. The uploader allows you to configure how it should respond to this scenario. There are three possible behaviours:
+Occasionally, a file with a matching name might already exist at the destination you would like to upload to. The uploader allows you to configure how it should respond to this scenario. There are four possible behaviours:
 
 ::
 
@@ -81,15 +81,13 @@ Occasionally, a file with a matching name might already exist at the destination
     $uploader->onDuplicateIncrement();
 
     // replace old file with new one, update existing Media record
-    $uploader->onDuplicateReplace();
+    $uploader->onDuplicateUpdate();
 
-    // replace old file with new one, delete existing Media record
-    $uploader->onDuplicateDelete();
+    // replace old file and media record with new ones
+    $uploader->onDuplicateReplace();
 
     // cancel upload, throw an exception
     $uploader->onDuplicateError();
-
-:note: In previous versions, ``onDuplicateReplace()`` behaved like ``onDuplicateDelete()``
 
 Validation
 --------------------

--- a/src/MediaUploader.php
+++ b/src/MediaUploader.php
@@ -732,13 +732,8 @@ class MediaUploader
                 $this->deleteExistingMedia($model);
                 break;
             case static::ON_DUPLICATE_UPDATE:
-                $model->{$model->getKeyName()} = Media::where('disk', $model->disk)
-                    ->where('directory', $model->directory)
-                    ->where('filename', $model->filename)
-                    ->where('extension', $model->extension)
-                    ->pluck($model->getKeyName())
-                    ->first();
-
+                $model->{$model->getKeyName()} = Media::forPathOnDisk(
+                    $model->disk, $model->getDiskPath())->pluck($model->getKeyName())->first();
                 $model->exists = true;
                 break;
             case static::ON_DUPLICATE_INCREMENT:

--- a/src/MediaUploader.php
+++ b/src/MediaUploader.php
@@ -27,7 +27,7 @@ class MediaUploader
     const ON_DUPLICATE_REPLACE = 'replace';
     const ON_DUPLICATE_INCREMENT = 'increment';
     const ON_DUPLICATE_ERROR = 'error';
-    const ON_DUPLICATE_DELETE = 'delete';
+    const ON_DUPLICATE_UPDATE = 'update';
 
     /**
      * @var FileSystemManager
@@ -264,9 +264,9 @@ class MediaUploader
      * Overwrite the existing file, updating the original media record
      * @return $this
      */
-    public function onDuplicateReplace()
+    public function onDuplicateUpdate()
     {
-        return $this->setOnDuplicateBehavior(self::ON_DUPLICATE_REPLACE);
+        return $this->setOnDuplicateBehavior(self::ON_DUPLICATE_UPDATE);
     }
 
     /**
@@ -276,9 +276,9 @@ class MediaUploader
      *
      * @return $this
      */
-    public function onDuplicateDelete()
+    public function onDuplicateReplace()
     {
-        return $this->setOnDuplicateBehavior(self::ON_DUPLICATE_DELETE);
+        return $this->setOnDuplicateBehavior(self::ON_DUPLICATE_REPLACE);
     }
 
     /**
@@ -728,10 +728,10 @@ class MediaUploader
             case static::ON_DUPLICATE_ERROR:
                 throw FileExistsException::fileExists($model->getDiskPath());
                 break;
-            case static::ON_DUPLICATE_DELETE:
+            case static::ON_DUPLICATE_REPLACE:
                 $this->deleteExistingMedia($model);
                 break;
-            case static::ON_DUPLICATE_REPLACE:
+            case static::ON_DUPLICATE_UPDATE:
                 $model->{$model->getKeyName()} = Media::where('disk', $model->disk)
                     ->where('directory', $model->directory)
                     ->where('filename', $model->filename)

--- a/tests/integration/MediaUploaderTest.php
+++ b/tests/integration/MediaUploaderTest.php
@@ -271,8 +271,8 @@ class MediaUploaderTest extends TestCase
         ]);
         $this->seedFileForMedia($media, $this->sampleFile());
 
-        $ca = $media->created_at;
-        $ua = $media->updated_at;
+        $createdAt = $media->created_at;
+        $updatedAt = $media->updated_at;
 
         sleep(1); // required to check the update time is different
 
@@ -281,8 +281,8 @@ class MediaUploaderTest extends TestCase
             ->toDestination('tmp', '')
             ->upload();
         $media = $media->fresh();
-        $this->assertEquals($media->created_at, $ca);
-        $this->assertNotEquals($media->updated_at, $ua);
+        $this->assertEquals($media->created_at, $createdAt);
+        $this->assertNotEquals($media->updated_at, $updatedAt);
 
         $this->assertEquals($media->getKey(), $result->getKey());
         $this->assertEquals('image', $media->aggregate_type);


### PR DESCRIPTION
**WARNING: This PR will introduce breaking changes!**

This is the 3.0 equivalent of #84. I personally thought the previous terms for the on duplicate behaviour was clearer, however, if people have already updated to 3.0, then this will introduce breaking changes. So I am unsure if this should be merged or not.

This PR will remap the duplicate behaviour:

| From  | To |
| ------------- | ------------- |
| ON_DUPLICATE_DELETE  | ON_DUPLICATE_REPLACE  |
| ON_DUPLICATE_REPLACE  | ON_DUPLICATE_UPDATE  |
| ON_DUPLICATE_INCREMENT  | ON_DUPLICATE_INCREMENT  |
| ON_DUPLICATE_ERROR  | ON_DUPLICATE_ERROR  |

Which will mean the duplicate terms will be consistent between 2.0 and 3.0, but will also be less confusing for people upgrading between the two versions