### PR TITLE
Assert headers are read safely from remote URLs

### DIFF
--- a/src/SourceAdapters/RemoteUrlAdapter.php
+++ b/src/SourceAdapters/RemoteUrlAdapter.php
@@ -102,14 +102,15 @@ class RemoteUrlAdapter implements SourceAdapterInterface
     }
 
     /**
-     * Read the headers of the remote content.
+     * Read a header value by name from the remote content.
+     *
      * @param  mixed $key Header name
      * @return mixed
      */
     private function getHeader($key)
     {
         if (! $this->headers) {
-            $this->headers = get_headers($this->source, 1);
+            $this->headers = $this->getHeaders();
         }
         if (array_key_exists($key, $this->headers)) {
             //if redirects encountered, return the final values
@@ -119,5 +120,17 @@ class RemoteUrlAdapter implements SourceAdapterInterface
                 return $this->headers[$key];
             }
         }
+    }
+
+    /**
+     * Read all the headers from the remote content.
+     *
+     * @return array
+     */
+    public function getHeaders()
+    {
+        $headers = @get_headers($this->source, 1);
+
+        return $headers ?: [];
     }
 }

--- a/tests/integration/SourceAdapters/SourceAdapterTest.php
+++ b/tests/integration/SourceAdapters/SourceAdapterTest.php
@@ -68,6 +68,8 @@ class SourceAdapterTest extends TestCase
         return [
             [new FileAdapter(new File($file, false))],
             [new LocalPathAdapter($file)],
+            [new RemoteUrlAdapter($url)],
+            [new RemoteUrlAdapter('http://example.invalid')],
             [new UploadedFileAdapter(new UploadedFile($file, 'invalid.png', 'image/png', 8444, UPLOAD_ERR_CANT_WRITE, false))],
             [new StreamResourceAdapter(fopen(realpath(__DIR__.'/../../_data/plank.png'), 'a'))],
             [new StreamResourceAdapter(fopen('php://stdin', 'w'))],


### PR DESCRIPTION
When getting headers from invalid URLs (e.g. because of DNS issues), PHP throws an warning instead of returning false.

https://stackoverflow.com/questions/17154458/get-headers-is-throwing-a-warning-instead-of-just-returning-false

This commit addresses the issue by disabling the warning and returning an empty array.