### PR TITLE
Fix windows paths pattern

### DIFF
--- a/config/mediable.php
+++ b/config/mediable.php
@@ -201,7 +201,7 @@ return [
         'pattern' => [
             '^https?://' => Plank\Mediable\SourceAdapters\RemoteUrlAdapter::class,
             '^/' => Plank\Mediable\SourceAdapters\LocalPathAdapter::class,
-            '^[a-zA-Z]:\\' => Plank\Mediable\SourceAdapters\LocalPathAdapter::class
+            '^[a-zA-Z]:\\\\' => Plank\Mediable\SourceAdapters\LocalPathAdapter::class
         ],
     ],
 


### PR DESCRIPTION
a fix for windows paths pattern, current pattern will result in a broken regex: ```/^[a-zA-Z]:\/i``` 