### PR TITLE
Add configurable table name for mediables joining table

### DIFF
--- a/config/mediable.php
+++ b/config/mediable.php
@@ -9,6 +9,11 @@ return [
     'model' => Plank\Mediable\Media::class,
 
     /*
+     * Name to be used for mediables joining table
+     */
+    'mediables_table' => 'mediables',
+
+    /*
      * Filesystem disk to use if none is specified
      */
     'default_disk' => 'public',

--- a/docs/source/mediable.rst
+++ b/docs/source/mediable.rst
@@ -308,3 +308,15 @@ Soft Deletes
 If your ``Mediable`` class uses Laravel's ``SoftDeletes`` trait, the model will only detach its media relationships if ``forceDelete()`` is used.
 
 You can change the ``detach_on_soft_delete`` setting to ``true`` in ``config/mediable.php`` to have relationships automatically detach when either the ``Media`` record or ``Mediable`` model are soft deleted.
+
+Custom Mediables Table
+----------------------
+
+By default the ``mediables`` table is used to for the media-to-mediables relationship. You can change this in ``config/mediable.php``:
+
+::
+
+    /*
+     * Name to be used for mediables joining table
+     */
+    'mediables_table' => 'prefixed_mediables',

--- a/migrations/2016_06_27_000001_create_mediable_test_tables.php
+++ b/migrations/2016_06_27_000001_create_mediable_test_tables.php
@@ -25,6 +25,21 @@ class CreateMediableTestTables extends Migration
         Schema::table('media', function (Blueprint $table) {
             $table->softDeletes();
         });
+
+        Schema::create('prefixed_mediables', function (Blueprint $table) {
+            $table->integer('media_id')->unsigned();
+            $table->string('mediable_type');
+            $table->integer('mediable_id')->unsigned();
+            $table->string('tag');
+            $table->integer('order')->unsigned();
+
+            $table->primary(['media_id', 'mediable_type', 'mediable_id', 'tag']);
+            $table->index(['mediable_id', 'mediable_type']);
+            $table->index('tag');
+            $table->index('order');
+            $table->foreign('media_id')->references('id')->on('media')
+                ->onDelete('cascade');
+        });
     }
 
     /**
@@ -38,5 +53,6 @@ class CreateMediableTestTables extends Migration
             $table->dropColumn('deleted_at');
         });
         Schema::drop('sample_mediables');
+        Schema::drop('prefixed_mediables');
     }
 }

--- a/src/Media.php
+++ b/src/Media.php
@@ -62,7 +62,13 @@ class Media extends Model
      */
     public function models($class)
     {
-        return $this->morphedByMany($class, 'mediable')->withPivot('tag', 'order');
+        return $this
+            ->morphedByMany(
+                $class,
+                'mediable',
+                config('mediable.mediables_table', 'mediables')
+            )
+            ->withPivot('tag', 'order');
     }
 
     /**
@@ -253,7 +259,7 @@ class Media extends Model
         if (static::hasGlobalScope(SoftDeletingScope::class) && ! $this->forceDeleting) {
             if (config('mediable.detach_on_soft_delete')) {
                 $this->newBaseQueryBuilder()
-                    ->from('mediables')
+                    ->from(config('mediable.mediables_table', 'mediables'))
                     ->where('media_id', $this->getKey())
                     ->delete();
             }

--- a/src/Mediable.php
+++ b/src/Mediable.php
@@ -43,7 +43,12 @@ trait Mediable
      */
     public function media()
     {
-        return $this->morphToMany(config('mediable.model'), 'mediable')
+        return $this
+            ->morphToMany(
+                config('mediable.model'),
+                'mediable',
+                config('mediable.mediables_table', 'mediables')
+            )
             ->withPivot('tag', 'order')
             ->orderBy('order');
     }

--- a/tests/integration/MediableTest.php
+++ b/tests/integration/MediableTest.php
@@ -3,6 +3,7 @@
 use Plank\Mediable\Media;
 use Plank\Mediable\MediableCollection;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
+use Illuminate\Support\Facades\DB;
 
 class MediableTest extends TestCase
 {
@@ -419,5 +420,17 @@ class MediableTest extends TestCase
         $query = $mediable->media()->unordered()->toSql();
 
         $this->assertNotRegExp('/order by `order`/i', $query);
+    }
+
+    public function test_it_can_create_mediables_on_custom_table()
+    {
+        config()->set('mediable.mediables_table', 'prefixed_mediables');
+
+        $media = factory(Media::class)->create();
+        $mediable = factory(SampleMediable::class)->create();
+        $mediable->attachMedia($media, 'foo');
+
+        $this->assertEmpty(DB::table('mediables')->get());
+        $this->assertCount(1, DB::table('prefixed_mediables')->get());
     }
 }


### PR DESCRIPTION
Hey Plank,

First off awesome package, thanks to everyone involved!

We're using laravel-mediable, but we need to use different table names. We've followed the [advice given](https://github.com/plank/laravel-mediable/issues/76#issuecomment-321300544) by @frasmage, which certainly works for the Media class itself. However, we feel that overriding the trait and copying the code from the original is a little brittle and could require unnecessary maintenance if laravel-mediable ever updates the base method for example.

As such, one proposal which this PR offers is to take the table name from the config file. The table name falls back to `mediables` in its absence, which (to the best of my knowledge) would make it a non-breaking change for all existing projects using the package.

This PR is meant to simply discuss the issue we're having. Should you be happy to accept it, I'll go ahead and update the PR with changes to the documentation and add any unit tests that seem reasonable.

Thanks again.