### PR TITLE
Add support for Laravel 6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,14 @@
 language: php
 php:
-  - '5.6'
-  - '7.0'
+  - '7.2'
+  - '7.3'
 before_script:
   - composer update --prefer-dist --prefer-stable
 script:
   - mkdir -p build/logs
   - vendor/bin/phpunit --coverage-clover build/logs/clover.xml
 after_script:
-  - php vendor/bin/coveralls -v
+  - php vendor/bin/php-coveralls -v
 branches:
   only:
   - master

--- a/composer.json
+++ b/composer.json
@@ -10,19 +10,19 @@
         }
     ],
     "require": {
-        "php": ">=5.4.0",
-        "illuminate/support": "^5.2.0",
-        "illuminate/filesystem": "^5.2.0",
-        "illuminate/database": "^5.2.0",
+        "php": "^7.2",
+        "illuminate/support": "^5.2.0|^6.0",
+        "illuminate/filesystem": "^5.2.0|^6.0",
+        "illuminate/database": "^5.2.0|^6.0",
         "league/flysystem": "^1.0.8",
         "psr/http-message": "^1.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^3.0",
-        "phpunit/phpunit": "^5.7",
-        "vlucas/phpdotenv": "^2.2",
+        "orchestra/testbench": "^3.2|^4.0",
+        "phpunit/phpunit": "^5.7|^8.0",
+        "vlucas/phpdotenv": "^2.2|^3.3",
         "league/flysystem-aws-s3-v3" : "^1.0.8",
-        "satooshi/php-coveralls": "^1.0.1"
+        "php-coveralls/php-coveralls": "^2.1"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -7,9 +7,7 @@
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
          processIsolation="false"
-         stopOnFailure="false"
-         syntaxCheck="false"
->
+         stopOnFailure="false">
     <testsuites>
         <testsuite name="Package Test Suite">
             <directory suffix=".php">./tests/integration/</directory>

--- a/src/Helpers/File.php
+++ b/src/Helpers/File.php
@@ -39,9 +39,12 @@ class File
             return '0 '.$units[0];
         }
         $exponent = floor(log($bytes, 1024));
-        $value = $bytes / pow(1024, $exponent);
+        $value = $bytes / 1024 ** $exponent;
 
-        return round($value, $precision).' '.$units[$exponent];
+        return vsprintf('%s %s', [
+            round($value, $precision),
+            $units[$exponent],
+        ]);
     }
 
     /**

--- a/src/MediaUploader.php
+++ b/src/MediaUploader.php
@@ -381,13 +381,13 @@ class MediaUploader
         $types_for_mime = $this->possibleAggregateTypesForMimeType($mime_type);
         $types_for_extension = $this->possibleAggregateTypesForExtension($extension);
 
-        if (count($allowed_types)) {
+        if (count($allowed_types) > 0) {
             $intersection = array_intersect($types_for_mime, $types_for_extension, $allowed_types);
         } else {
             $intersection = array_intersect($types_for_mime, $types_for_extension);
         }
 
-        if (count($intersection)) {
+        if (count($intersection) > 0) {
             $type = $intersection[0];
         } elseif (empty($types_for_mime) && empty($types_for_extension)) {
             if (! $this->config['allow_unrecognized_types']) {
@@ -761,7 +761,7 @@ class MediaUploader
         do {
             $filename = "{$model->filename}";
             if ($counter > 0) {
-                $filename .= '-' . $counter;
+                $filename .= "-{$counter}";
             }
             $path = "{$model->directory}/{$filename}.{$model->extension}";
             ++$counter;

--- a/src/Mediable.php
+++ b/src/Mediable.php
@@ -476,8 +476,7 @@ trait Mediable
 
         $empty = array_combine($tags, array_fill(0, count($tags), 0));
 
-        $merged = collect($result)->toArray() + $empty;
-        return $merged;
+        return collect($result)->toArray() + $empty;
     }
 
     /**

--- a/src/Stream.php
+++ b/src/Stream.php
@@ -221,8 +221,10 @@ class Stream implements StreamInterface
         $result = fseek($this->resource, $offset, $whence);
 
         if ($result === -1) {
-            throw new \RuntimeException('Unable to seek to stream position '
-                . $offset . ' with whence ' . var_export($whence, true));
+            throw new \RuntimeException(vsprintf('Unable to seek to stream position %d with whence %s', [
+                $offset,
+                var_export($whence, true),
+            ]));
         }
 
         return true;
@@ -285,6 +287,6 @@ class Stream implements StreamInterface
             return $metadata;
         }
 
-        return isset($metadata[$key]) ? $metadata[$key] : null;
+        return $metadata[$key] ?? null;
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -9,7 +9,7 @@ class TestCase extends BaseTestCase
 {
     protected $queriesCount;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->withFactories(__DIR__.'/_factories');

--- a/tests/integration/Commands/ImportMediaCommandTest.php
+++ b/tests/integration/Commands/ImportMediaCommandTest.php
@@ -6,7 +6,7 @@ use Illuminate\Contracts\Console\Kernel as Artisan;
 
 class ImportMediaCommandTest extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->useDatabase();

--- a/tests/integration/Commands/PruneMediaCommandTest.php
+++ b/tests/integration/Commands/PruneMediaCommandTest.php
@@ -5,7 +5,7 @@ use Illuminate\Contracts\Console\Kernel as Artisan;
 
 class PruneMediaCommandTest extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->useDatabase();

--- a/tests/integration/HandlesMediaExceptionsTest.php
+++ b/tests/integration/HandlesMediaExceptionsTest.php
@@ -106,7 +106,7 @@ class HandlesMediaExceptionsTest extends TestCase
             new Exception()
         );
 
-        $this->assertFalse($e instanceof HttpException);
+        $this->assertNotInstanceOf(HttpException::class, $e);
     }
 
     protected function assertHttpException($e, $code)

--- a/tests/integration/MediaTest.php
+++ b/tests/integration/MediaTest.php
@@ -247,7 +247,7 @@ class MediaTest extends TestCase
 
         $this->assertFileExists($path);
         $media->delete();
-        $this->assertFalse(file_exists($path));
+        $this->assertFileNotExists($path);
     }
 
     public function test_it_cascades_relationship_on_delete()

--- a/tests/integration/MediableCollectionTest.php
+++ b/tests/integration/MediableCollectionTest.php
@@ -5,7 +5,7 @@ use Plank\Mediable\MediableCollection;
 
 class MediableCollectionTest extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->useDatabase();

--- a/tests/integration/MediableTest.php
+++ b/tests/integration/MediableTest.php
@@ -7,7 +7,7 @@ use Illuminate\Support\Facades\DB;
 
 class MediableTest extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->useDatabase();

--- a/tests/integration/SourceAdapters/SourceAdapterTest.php
+++ b/tests/integration/SourceAdapters/SourceAdapterTest.php
@@ -14,7 +14,7 @@ use Psr\Http\Message\StreamInterface;
 
 class SourceAdapterTest extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
     }
@@ -128,7 +128,7 @@ class SourceAdapterTest extends TestCase
     {
         $adapter = new $adapter($source);
 
-        $this->assertInternalType('string', $adapter->contents());
+        $this->assertIsString($adapter->contents());
     }
 
     /**

--- a/tests/integration/UrlGenerators/S3UrlGeneratorTest.php
+++ b/tests/integration/UrlGenerators/S3UrlGeneratorTest.php
@@ -8,9 +8,8 @@ use Illuminate\Routing\UrlGenerator as Url;
 
 class S3UrlGeneratorTest extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
-        parent::setup();
         if (!$this->s3ConfigLoaded()) {
             $this->markTestSkipped('S3 Credentials not available.');
         }


### PR DESCRIPTION
In order to keep compatibility with PHP <7.1, I have removed all the `setUp()` methods in the tests because PHPUnit 8 requires the `void` return type in PHP >=7..1