### PR TITLE
UrlGenerators use filesystem::url() method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 4.0.0
+- changed UrlGenerators to use the underlying filesystemAdapter's `url()` method
+- UrlGenerators no longer throw `MediaUrlException` when the file does not have public visibility. This removes the need to read IO for files local disks or to make HTTP calls for files on s3 disks.
+- Removed `LocalUrlGenerator::getPublicPath()`
+- No longer reading the `'prefix'` config of local disks. Value should be included in the `'url'` config instead.  
+
 ## 3.0.1 - 2019-09-18
 - Fixed public visibility not being respected when generating URLs for local files that are not in the webroot.
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,5 +1,11 @@
 # Upgrading
 
+## 3.x to 4.x
+
+* UrlGenerators no longer throw `MediaUrlException` when the file does not have public visibility. This removes the need to read IO for files local disks or to make HTTP calls for files on s3 disks. Visibility can still checked with `$media->isPubliclyAccessible()`, if necessary.
+* Highly recommended to explicitly specify the `'url'` config value on all disks used to generate URLs.
+* No longer reading the `'prefix'` config of local disks. Value should be included in the `'url'` config instead.  
+
 ## 2.x to 3.x
 
 * Minimum PHP version moved to 7.2

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -10,8 +10,6 @@ Disks
 ------------------------
 Laravel-Mediable is built on top of Laravel's Filesystem component. Before you use the package, you will need to configure the filesystem disks where you would like files to be stored in ``config/filesystems.php``. `Learn more about filesystem disk <https://laravel.com/docs/5.2/filesystem>`_.
 
-An example setup with one private disk (``local``) and one publicly accessible disk (``uploads``):
-
 ::
 
     <?php
@@ -20,11 +18,15 @@ An example setup with one private disk (``local``) and one publicly accessible d
         'local' => [
             'driver' => 'local',
             'root'   => storage_path('app'),
+            'url' => 'https://example.com/storage/app',
+            'visibility' => 'public'
         ],
 
         'uploads' => [
             'driver' => 'local',
             'root'   => public_path('uploads'),
+            'url' => 'https://example.com/uploads',
+            'visibility' => 'public'
         ],
     ]
     //...
@@ -45,124 +47,10 @@ Once you have set up as many disks as you need, edit ``config/mediable.php`` to 
      * Filesystems that can be used for media storage
      */
     'allowed_disks' => [
+        'local',
         'uploads',
     ],
     //...
-
-.. _disk_visibility:
-
-Disk Visibility
-^^^^^^^^^^^^^^^
-
-This package is able to generate public URLs for accessing media, and uses the disk config to determine how this should be done.
-
-URLs can always be generated for ``Media`` placed on a disk located below the webroot.
-
-::
-
-    <?php
-    'disks' => [
-        'uploads' => [
-            'driver' => 'local',
-            'root' => public_path('uploads'),
-        ],
-    ]
-
-    //...
-
-    $media->getUrl(); // returns http://domain.com/uploads/foo.jpg
-
-``Media`` placed on a disk located elsewhere will throw an exception.
-
-::
-
-    <?php
-    'disks' => [
-        'private' => [
-            'driver' => 'local',
-            'root' => storage_path('private'),
-        ],
-    ]
-
-    //...
-
-    $media->getUrl(); // Throws a Plank\Mediable\Exceptions\MediableUrlException
-
-If you are using symbolic links to make local disks accessible, you can instruct the package to generate URLs with the ``'visibility' => 'public'`` key. By default, the package will assume that the symlink is named ``'storage'``, as per `laravel's documentation <https://laravel.com/docs/5.3/filesystem#the-public-disk>`_. This can be modified with the ``'prefix'`` key.
-
-::
-
-    <?php
-    'disks' => [
-        'public' => [
-            'driver' => 'local',
-            'root' => storage_path('public'),
-            'visibility' => 'public',
-            'prefix' => 'assets'
-        ],
-    ]
-
-    //...
-
-    $media->getUrl(); // returns http://domain.com/assets/foo.jpg
-
-Whether you are using symbolic links or not, you can set the ``'url'`` config value to generate disk urls on another domain. Note that you can specify any path in the url, as the root path doesn't have to match, as long as you have set up your web server accordingly.
-
-::
-
-    <?php
-    'disks' => [
-        'uploads' => [
-            'driver' => 'local',
-            'root' => public_path('uploads'),
-            'url' => 'http://example.com/assets',
-        ],
-    ]
-
-    //...
-
-    $media->getUrl(); // returns http://example.com/assets/foo.jpg
-
-However, if you are using a symbolic link to make a local disk accessible, the prefix will be appended to the disk url.
-
-::
-
-    <?php
-    'disks' => [
-        'public' => [
-            'driver' => 'local',
-            'root' => storage_path('public'),
-            'visibility' => 'public',
-            'prefix' => 'assets',
-            'url' => 'http://example.com',
-        ],
-    ]
-
-    //...
-
-    $media->getUrl(); // returns http://example.com/assets/foo.jpg
-
-
-Permissions for S3-based disks is set on the buckets themselves. You can inform the package that ``Media`` on an S3 disk can be linked by URL by adding the ``'visibility' => 'public'`` key to the disk config.
-
-::
-
-    <?php
-    'disks' => [
-        'cloud' => [
-            'driver' => 's3',
-            'key'    => env('S3_KEY'),
-            'secret' => env('S3_SECRET'),
-            'region' => env('S3_REGION'),
-            'bucket' => env('S3_BUCKET'),
-            'version' => 'latest',
-            'visibility' => 'public'
-        ],
-    ]
-
-    //...
-
-    $media->getUrl(); // returns https://s3.amazonaws.com/bucket/foo.jpg
 
 
 .. _validation:

--- a/src/Exceptions/MediaUrlException.php
+++ b/src/Exceptions/MediaUrlException.php
@@ -19,15 +19,4 @@ class MediaUrlException extends Exception
     {
         return new static("Could not set UrlGenerator, class `{$class}` does not extend `Plank\Mediable\UrlGenerators\UrlGenerator`");
     }
-
-    public static function mediaNotPubliclyAccessible(string $path): self
-    {
-        $public_path = public_path();
-        return new static("Media file `{$path}` is not part of the public path `{$public_path}`");
-    }
-
-    public static function cloudMediaNotPubliclyAccessible(string $disk): self
-    {
-        return new static("Media files on cloud disk `{$disk}` are not publicly accessible");
-    }
 }

--- a/src/UrlGenerators/LocalUrlGenerator.php
+++ b/src/UrlGenerators/LocalUrlGenerator.php
@@ -4,25 +4,25 @@ declare(strict_types=1);
 namespace Plank\Mediable\UrlGenerators;
 
 use Illuminate\Contracts\Config\Repository as Config;
-use Illuminate\Contracts\Routing\UrlGenerator;
-use Plank\Mediable\Exceptions\MediaUrlException;
+use Illuminate\Contracts\Filesystem\Cloud;
+use Illuminate\Filesystem\FilesystemManager;
 
 class LocalUrlGenerator extends BaseUrlGenerator
 {
     /**
-     * @var UrlGenerator
+     * @var FilesystemManager
      */
-    protected $url;
+    protected $filesystem;
 
     /**
      * Constructor.
      * @param Config $config
-     * @param UrlGenerator $url
+     * @param FilesystemManager $filesystem
      */
-    public function __construct(Config $config, UrlGenerator $url)
+    public function __construct(Config $config, FilesystemManager $filesystem)
     {
         parent::__construct($config);
-        $this->url = $url;
+        $this->filesystem = $filesystem;
     }
 
     /**
@@ -30,26 +30,8 @@ class LocalUrlGenerator extends BaseUrlGenerator
      */
     public function isPubliclyAccessible(): bool
     {
-        return (parent::isPubliclyAccessible() || $this->isInWebroot()) && $this->media->isVisible();
-    }
-
-    /**
-     * Get the path to relative to the webroot.
-     * @return string
-     * @throws MediaUrlException If media's disk is not publicly accessible
-     */
-    public function getPublicPath(): string
-    {
-        if (!$this->isPubliclyAccessible()) {
-            throw MediaUrlException::mediaNotPubliclyAccessible($this->getAbsolutePath());
-        }
-        if ($this->isInWebroot()) {
-            $path = str_replace(public_path(), '', $this->getAbsolutePath());
-        } else {
-            $path = rtrim($this->getPrefix(), '/') . '/' . $this->media->getDiskPath();
-        }
-
-        return $this->cleanDirectorySeparators($path);
+        return ($this->getDiskConfig('visibility', 'private') == 'public' || $this->isInWebroot())
+            && $this->media->isVisible();
     }
 
     /**
@@ -58,19 +40,9 @@ class LocalUrlGenerator extends BaseUrlGenerator
      */
     public function getUrl(): string
     {
-        $path = $this->getPublicPath();
-
-        $url = $this->getDiskConfig('url');
-
-        if ($url) {
-            if ($this->isInWebroot()) {
-                $path = $this->media->getDiskPath();
-            }
-
-            return rtrim($url, '/') . '/' . trim($path, '/');
-        }
-
-        return $this->url->asset($path);
+        /** @var Cloud $filesystem */
+        $filesystem = $this->filesystem->disk($this->media->disk);
+        return $filesystem->url($this->media->getDiskPath());
     }
 
     /**
@@ -81,44 +53,8 @@ class LocalUrlGenerator extends BaseUrlGenerator
         return $this->getDiskConfig('root') . DIRECTORY_SEPARATOR . $this->media->getDiskPath();
     }
 
-    /**
-     * Correct directory separator slashes on non-unix systems.
-     * @param  string $path
-     * @return string
-     */
-    protected function cleanDirectorySeparators(string $path): string
-    {
-        if (DIRECTORY_SEPARATOR != '/') {
-            $path = str_replace(DIRECTORY_SEPARATOR, '/', $path);
-        }
-
-        return $path;
-    }
-
     private function isInWebroot(): bool
     {
         return strpos(realpath($this->getAbsolutePath()), realpath(public_path())) === 0;
-    }
-
-    /**
-     * Get the prefix.
-     *
-     * If the prefix and the url are not set, we will assume the prefix
-     * is "storage", in order to point to the default symbolic link.
-     *
-     * Otherwise, we will trust the user has correctly set the prefix and/or the url.
-     *
-     * @return string
-     */
-    private function getPrefix()
-    {
-        $prefix = $this->getDiskConfig('prefix', '');
-        $url = $this->getDiskConfig('url');
-
-        if (!$prefix && !$url) {
-            return 'storage';
-        }
-
-        return $prefix;
     }
 }

--- a/src/UrlGenerators/S3UrlGenerator.php
+++ b/src/UrlGenerators/S3UrlGenerator.php
@@ -6,7 +6,6 @@ namespace Plank\Mediable\UrlGenerators;
 use Illuminate\Contracts\Config\Repository as Config;
 use Illuminate\Contracts\Filesystem\Cloud;
 use Illuminate\Filesystem\FilesystemManager;
-use Plank\Mediable\Exceptions\MediaUrlException;
 
 class S3UrlGenerator extends BaseUrlGenerator
 {
@@ -40,10 +39,6 @@ class S3UrlGenerator extends BaseUrlGenerator
      */
     public function getUrl(): string
     {
-        if (!$this->isPubliclyAccessible()) {
-            throw MediaUrlException::cloudMediaNotPubliclyAccessible($this->media->disk);
-        }
-
         /** @var Cloud $filesystem */
         $filesystem = $this->filesystem->disk($this->media->disk);
         return $filesystem->url($this->media->getDiskPath());

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -51,13 +51,13 @@ class TestCase extends BaseTestCase
             'uploads' => [
                 'driver' => 'local',
                 'root' => public_path('uploads'),
+                'url' => 'http://localhost/uploads',
                 'visibility' => 'public'
             ],
             'public_storage' => [
                 'driver' => 'local',
                 'root' => storage_path('public'),
                 'url' => 'http://localhost/storage',
-                'prefix' => '',
                 'visibility' => 'public',
             ],
             's3' => [

--- a/tests/integration/UrlGenerators/LocalUrlGeneratorTest.php
+++ b/tests/integration/UrlGenerators/LocalUrlGeneratorTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use Plank\Mediable\Exceptions\MediaUrlException;
+use Illuminate\Filesystem\FilesystemManager;
 use Plank\Mediable\Media;
 use Plank\Mediable\UrlGenerators\LocalUrlGenerator;
 
@@ -18,33 +18,10 @@ class LocalUrlGeneratorTest extends TestCase
         $this->assertEquals('http://localhost/uploads/foo/bar.jpg', $generator->getUrl());
     }
 
-    public function test_it_generates_custom_url()
-    {
-        $this->app['config']->set('filesystems.disks.uploads.url', 'http://example.com');
-        $generator = $this->setupGenerator();
-        $this->assertEquals('http://example.com/foo/bar.jpg', $generator->getUrl());
-    }
-
-    public function test_it_generates_prefixed_url()
-    {
-        $this->app['config']->set('filesystems.disks.public_storage.url', null);
-        $this->app['config']->set('filesystems.disks.public_storage.prefix', 'uploads');
-        $generator = $this->setupGenerator('public_storage');
-        $this->assertEquals('http://localhost/uploads/foo/bar.jpg', $generator->getUrl());
-    }
-
-    public function test_it_generates_prefixed_custom_url()
-    {
-        $this->app['config']->set('filesystems.disks.public_storage.prefix', 'uploads');
-        $generator = $this->setupGenerator('public_storage');
-        $this->assertEquals('http://localhost/storage/uploads/foo/bar.jpg', $generator->getUrl());
-    }
-
-    public function test_it_throws_exception_for_non_public_disk()
+    public function test_it_attempts_to_generate_url_for_non_public_disk()
     {
         $generator = $this->setupGenerator('tmp');
-        $this->expectException(MediaUrlException::class);
-        $generator->getPublicPath();
+        $this->assertEquals('/storage/foo/bar.jpg', $generator->getUrl());
     }
 
     public function test_it_accepts_public_visibility()
@@ -55,6 +32,7 @@ class LocalUrlGeneratorTest extends TestCase
 
     protected function setupGenerator($disk = 'uploads')
     {
+        /** @var Media $media */
         $media = factory(Media::class)->make([
             'disk' => $disk,
             'directory' => 'foo',
@@ -63,7 +41,7 @@ class LocalUrlGeneratorTest extends TestCase
         ]);
         $this->useFilesystem($disk);
         $this->seedFileForMedia($media);
-        $generator = new LocalUrlGenerator(config(), url());
+        $generator = new LocalUrlGenerator(config(), app(FilesystemManager::class));
         $generator->setMedia($media);
         return $generator;
     }

--- a/tests/integration/UrlGenerators/S3UrlGeneratorTest.php
+++ b/tests/integration/UrlGenerators/S3UrlGeneratorTest.php
@@ -1,7 +1,6 @@
 <?php
 
 use Illuminate\Filesystem\FilesystemManager;
-use Plank\Mediable\Exceptions\MediaUrlException;
 use Plank\Mediable\Media;
 use Plank\Mediable\UrlGenerators\S3UrlGenerator;
 
@@ -40,14 +39,6 @@ class S3UrlGeneratorTest extends TestCase
             sprintf('https://%s.s3.%s.amazonaws.com/foo/bar.jpg', env('S3_BUCKET'), env('S3_REGION')),
             $generator->getUrl()
         );
-    }
-
-    public function test_it_throws_exception_if_not_available()
-    {
-        config()->set('filesystems.disks.s3.visibility', 'private');
-        $generator = $this->setupGenerator();
-        $this->expectException(MediaUrlException::class);
-        $generator->getUrl();
     }
 
     protected function setupGenerator()


### PR DESCRIPTION
- changed UrlGenerators to use the underlying filesystemAdapter's `url()` method (fixes #143)
- UrlGenerators no longer throw `MediaUrlException` when the file does not have public visibility. This removes the need to read IO for files local disks or to make HTTP calls for files on s3 disks (fixes #145).
- Removed `LocalUrlGenerator::getPublicPath()`
- No longer reading the `'prefix'` config of local disks. Value should be included in the `'url'` config instead.  