### PR TITLE
Address Symfony module deprecation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,7 @@
         "illuminate/filesystem": "^5.6|^6.0",
         "illuminate/database": "^5.6|^6.0",
         "league/flysystem": "~1.0.23",
-        "psr/http-message": "^1.0",
-        "symfony/http-foundation": "^4.3"
+        "psr/http-message": "^1.0"
     },
     "require-dev": {
         "orchestra/testbench": "^3.3|^4.0",

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
         "illuminate/filesystem": "^5.6|^6.0",
         "illuminate/database": "^5.6|^6.0",
         "league/flysystem": "~1.0.23",
-        "psr/http-message": "^1.0"
+        "psr/http-message": "^1.0",
+        "symfony/http-foundation": "^4.3"
     },
     "require-dev": {
         "orchestra/testbench": "^3.3|^4.0",

--- a/src/Helpers/File.php
+++ b/src/Helpers/File.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace Plank\Mediable\Helpers;
 
-use Symfony\Component\HttpFoundation\File\MimeType\ExtensionGuesser;
+use Symfony\Component\Mime\MimeTypes;
 
 class File
 {
@@ -48,12 +48,12 @@ class File
      * @param  string $mimeType
      * @return string|null The guessed extension or null if it cannot be guessed
      *
-     * @see ExtensionGuesser
+     * @see MimeTypes
      */
     public static function guessExtension(string $mimeType): ?string
     {
-        $guesser = ExtensionGuesser::getInstance();
+        $guesser = MimeTypes::getDefault();
 
-        return $guesser->guess($mimeType);
+        return $guesser->getExtensions($mimeType)[0] ?? null;
     }
 }

--- a/src/Helpers/File.php
+++ b/src/Helpers/File.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Plank\Mediable\Helpers;
 
+use Symfony\Component\HttpFoundation\File\MimeType\ExtensionGuesser;
 use Symfony\Component\Mime\MimeTypes;
 
 class File
@@ -52,8 +53,12 @@ class File
      */
     public static function guessExtension(string $mimeType): ?string
     {
-        $guesser = MimeTypes::getDefault();
+        // use Symfony MimeTypes component if available (symfony/http-foundation v4.3+)
+        if (class_exists(MimeTypes::class)) {
+            return MimeTypes::getDefault()->getExtensions($mimeType)[0] ?? null;
+        }
 
-        return $guesser->getExtensions($mimeType)[0] ?? null;
+        // fall back to the older ExtensionGuesser class (deprecated since Symfony 4.3)
+        return ExtensionGuesser::getInstance()->guess($mimeType);
     }
 }


### PR DESCRIPTION
Fix for this deprecation:

> PHP Deprecated: The "Symfony/Component/HttpFoundation/File/MimeType/ExtensionGuesser" class is deprecated since Symfony 4.3, use "Symfony/Component/Mime/MimeTypes" instead. 
