### PR TITLE
Fix timing of beforeSave callback

### DIFF
--- a/src/MediaUploader.php
+++ b/src/MediaUploader.php
@@ -490,14 +490,13 @@ class MediaUploader
         $this->verifyFile();
 
         $model = $this->populateModel($this->makeModel());
-        $this->verifyDestination($model);
 
         if (is_callable($this->before_save)) {
             call_user_func($this->before_save, $model, $this->source);
         }
 
+        $this->verifyDestination($model);
         $this->writeToDisk($model);
-
         $model->save();
 
         return $model;
@@ -539,11 +538,13 @@ class MediaUploader
 
         $model = $this->populateModel($media);
 
-        $this->verifyDestination($model);
+        if (is_callable($this->before_save)) {
+            call_user_func($this->before_save, $model, $this->source);
+        }
 
+        $this->verifyDestination($model);
         // Delete original file, if necessary
         $this->filesystem->disk($disk)->delete($path);
-
         $this->writeToDisk($model);
 
         $model->save();
@@ -643,6 +644,10 @@ class MediaUploader
         $model->size = $this->verifyFileSize($storage->size($model->getDiskPath()));
 
         $storage->setVisibility($model->getDiskPath(), $this->visibility);
+
+        if (is_callable($this->before_save)) {
+            call_user_func($this->before_save, $model, $this->source);
+        }
 
         $model->save();
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -7,6 +7,8 @@ use Plank\Mediable\Media;
 
 class TestCase extends BaseTestCase
 {
+    const TEST_FILE_SIZE = 7173;
+
     public function setUp(): void
     {
         parent::setUp();
@@ -141,6 +143,11 @@ class TestCase extends BaseTestCase
     protected function alternateFilePath()
     {
         return realpath(__DIR__ . '/_data/plank2.png');
+    }
+
+    protected function remoteFilePath()
+    {
+        return 'https://www.plankdesign.com/externaluse/plank.png';
     }
 
     protected function sampleFile()

--- a/tests/integration/Commands/ImportMediaCommandTest.php
+++ b/tests/integration/Commands/ImportMediaCommandTest.php
@@ -99,8 +99,8 @@ class ImportMediaCommandTest extends TestCase
             'mime_type' => 'image/png',
             'aggregate_type' => 'image'
         ]);
-        $this->seedFileForMedia($media1, fopen(__DIR__ . '/../../_data/plank.png', 'r'));
-        $this->seedFileForMedia($media2, fopen(__DIR__ . '/../../_data/plank.png', 'r'));
+        $this->seedFileForMedia($media1, fopen($this->sampleFilePath(), 'r'));
+        $this->seedFileForMedia($media2, fopen($this->sampleFilePath(), 'r'));
 
         $artisan->call('media:import', ['disk' => 'tmp', '--force' => true]);
         $this->assertEquals(['image', 'image'], Media::pluck('aggregate_type')->toArray());


### PR DESCRIPTION
Previously callback would occur after applying the on duplicate behaviour. This would result in potentially destructive changes being applied to an existing file before the callback changes disk/directory/filename to something else. It also results in no duplciate validation being performed after the path has been modified.

The callback is now called from the MediaUploader::replace() and MediaUploader::import() methods