### PR TITLE
Fix deprecated getClientSize method

### DIFF
--- a/src/SourceAdapters/UploadedFileAdapter.php
+++ b/src/SourceAdapters/UploadedFileAdapter.php
@@ -99,6 +99,6 @@ class UploadedFileAdapter implements SourceAdapterInterface
      */
     public function size(): int
     {
-        return (int)$this->source->getClientSize();
+        return (int)$this->source->getSize();
     }
 }

--- a/src/UrlGenerators/UrlGeneratorFactory.php
+++ b/src/UrlGenerators/UrlGeneratorFactory.php
@@ -70,6 +70,6 @@ class UrlGeneratorFactory
      */
     protected function getDriverForDisk(string $disk): string
     {
-        return config("filesystems.disks.{$disk}.driver");
+        return (string) config("filesystems.disks.{$disk}.driver");
     }
 }


### PR DESCRIPTION
Deprecated in Symphony 4.1, replacing with getSize()