### PR TITLE
Explicitly define the table name on the Media model

### DIFF
--- a/src/Media.php
+++ b/src/Media.php
@@ -48,6 +48,7 @@ class Media extends Model
     const TYPE_OTHER = 'other';
     const TYPE_ALL = 'all';
 
+    protected $table = 'media';
     protected $guarded = ['id', 'disk', 'directory', 'filename', 'extension', 'size', 'mime_type', 'aggregate_type'];
 
     /**


### PR DESCRIPTION
Fixes #175. A bug in doctrine/inflector:1.4.0 breaks the pluralization of media. This change removes the need to depend on the inflector.