### PR TITLE
removed redundant index

### DIFF
--- a/migrations/2016_06_27_000000_create_mediable_tables.php
+++ b/migrations/2016_06_27_000000_create_mediable_tables.php
@@ -24,7 +24,6 @@ class CreateMediableTables extends Migration
             $table->integer('size')->unsigned();
             $table->timestamps();
 
-            $table->index(['disk', 'directory']);
             $table->unique(['disk', 'directory', 'filename', 'extension']);
             $table->index('aggregate_type');
         });


### PR DESCRIPTION
the disk/directory index on the Media table is already handled by the disk/directory/filename/extension index