### PR TITLE
Fix bug with custom media table name

### DIFF
--- a/src/Commands/ImportMediaCommand.php
+++ b/src/Commands/ImportMediaCommand.php
@@ -80,7 +80,10 @@ class ImportMediaCommand extends Command
         $force = (bool)$this->option('force');
 
         $files = $this->listFiles($disk, $directory, $recursive);
-        $existing_media = Media::inDirectory($disk, $directory, $recursive)->get();
+        $existing_media = $this->makeModel()
+            ->newQuery()
+            ->inDirectory($disk, $directory, $recursive)
+            ->get();
 
         foreach ($files as $path) {
             if ($record = $this->getRecordForFile($path, $existing_media)) {
@@ -196,5 +199,16 @@ class ImportMediaCommand extends Command
             'updated' => 0,
             'skipped' => 0,
         ];
+    }
+
+    /**
+     * Generate an instance of the `Media` class.
+     * @return Media
+     */
+    private function makeModel(): Media
+    {
+        $class = config('mediable.model', Media::class);
+
+        return new $class;
     }
 }

--- a/src/Commands/PruneMediaCommand.php
+++ b/src/Commands/PruneMediaCommand.php
@@ -54,7 +54,10 @@ class PruneMediaCommand extends Command
         $recursive = !$this->option('non-recursive');
         $counter = 0;
 
-        $records = Media::inDirectory($disk, $directory, $recursive)->get();
+        $records = $this->makeModel()
+            ->newQuery()
+            ->inDirectory($disk, $directory, $recursive)
+            ->get();
 
         foreach ($records as $media) {
             if (!$media->fileExists()) {
@@ -65,5 +68,16 @@ class PruneMediaCommand extends Command
         }
 
         $this->info("Pruned {$counter} record(s).");
+    }
+
+    /**
+     * Generate an instance of the `Media` class.
+     * @return Media
+     */
+    private function makeModel(): Media
+    {
+        $class = config('mediable.model', Media::class);
+
+        return new $class;
     }
 }

--- a/src/MediaUploader.php
+++ b/src/MediaUploader.php
@@ -823,7 +823,8 @@ class MediaUploader
                 $this->deleteExistingMedia($model);
                 break;
             case static::ON_DUPLICATE_UPDATE:
-                $model->{$model->getKeyName()} = Media::where('disk', $model->disk)
+                $model->{$model->getKeyName()} = $model->newQuery()
+                    ->where('disk', $model->disk)
                     ->where('directory', $model->directory)
                     ->where('filename', $model->filename)
                     ->where('extension', $model->extension)
@@ -846,7 +847,8 @@ class MediaUploader
      */
     private function deleteExistingMedia(Media $model): void
     {
-        Media::where('disk', $model->disk)
+        $model->newQuery()
+            ->where('disk', $model->disk)
             ->where('directory', $model->directory)
             ->where('filename', $model->filename)
             ->where('extension', $model->extension)


### PR DESCRIPTION
MediaUploader and Commands now use custom media class from the config instead of Plank\Mediable\Media