### PR TITLE
Keep track of variants created from media

### DIFF
--- a/migrations/2016_06_27_000000_create_mediable_tables.php
+++ b/migrations/2016_06_27_000000_create_mediable_tables.php
@@ -22,10 +22,16 @@ class CreateMediableTables extends Migration
             $table->string('mime_type', 128);
             $table->string('aggregate_type', 32);
             $table->integer('size')->unsigned();
+            $table->string('variant_name', 255)->nullable();
+            $table->integer('original_media_id')->unsigned()->nullable();
             $table->timestamps();
 
             $table->unique(['disk', 'directory', 'filename', 'extension']);
             $table->index('aggregate_type');
+
+            $table->foreign('original_media_id')
+                ->references('id')->on('media')
+                ->nullOnDelete();
         });
 
         Schema::create('mediables', function (Blueprint $table) {
@@ -41,7 +47,7 @@ class CreateMediableTables extends Migration
             $table->index('order');
             $table->foreign('media_id')
                 ->references('id')->on('media')
-                ->onDelete('cascade');
+                ->cascadeOnDelete();
         });
     }
 

--- a/src/ImageManipulator.php
+++ b/src/ImageManipulator.php
@@ -72,6 +72,10 @@ class ImageManipulator
         $newMedia->mime_type = $this->getMimeTypeForOutputFormat($outputFormat);
         $newMedia->aggregate_type = Media::TYPE_IMAGE;
         $newMedia->size = $outputStream->getSize();
+        $newMedia->variant_name = $variantName;
+        $newMedia->original_media_id = $media->isOriginal()
+            ? $media->getKey()
+            : $media->original_media_id; // attach variants of variants to the same original
 
         if ($beforeSave = $manipulation->getBeforeSave()) {
             $beforeSave($newMedia);

--- a/tests/Mocks/SampleMediable.php
+++ b/tests/Mocks/SampleMediable.php
@@ -5,6 +5,9 @@ namespace Plank\Mediable\Tests\Mocks;
 use Illuminate\Database\Eloquent\Model;
 use Plank\Mediable\Mediable;
 
+/**
+ * @method static self first()
+ */
 class SampleMediable extends Model
 {
     use Mediable;


### PR DESCRIPTION
Media now have relationship to any variants created from them or to the original media that they were derived from.

added helper methods for eager loading these relationships, as well as finding a given variant of a Media instance