### PR TITLE
Variant creation now handles conflicts

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -3,7 +3,16 @@
 ## 4.x to 5.x
 
 * Two columns added to the `media` table: `variant_name` (varchar)  and `original_media_id` (should match `media.id` column type)
+
+    ```php
+    $table->string('variant_name', 255)->nullable();
+    $table->integer('original_media_id')->unsigned()->nullable();
+    $table->foreign('original_media_id')
+         ->references('id')->on('media')
+         ->nullOnDelete();
+    ```
 * `Plank\Mediable\MediaUploaderFacade` moved to `Plank\Mediable\Facades\MediaUploader`
+* Directory and filename validation now only allows URL and filesystem safe ASCII characters (alphanumeric plus `.`, `-`, `_`, and `/` for directories). Will automatically attempt to transliterate UTF-8 accented characters and ligatures into their ASCII equivalent, all other characters will be converted to hyphens.
 * The following methods now include an extra `$withVariants` parameter :
     * `Mediable::scopeWithMedia()`
     * `Mediable::scopeWithMediaMatchAll()`

--- a/src/Exceptions/ImageManipulationException.php
+++ b/src/Exceptions/ImageManipulationException.php
@@ -25,4 +25,9 @@ class ImageManipulationException extends \Exception
             "Unable to determine valid output format for file."
         );
     }
+
+    public static function fileExists(string $path): self
+    {
+        return new static("A file already exists at `{$path}`.");
+    }
 }

--- a/src/Helpers/File.php
+++ b/src/Helpers/File.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Plank\Mediable\Helpers;
 
+use Illuminate\Support\Str;
 use Symfony\Component\HttpFoundation\File\MimeType\ExtensionGuesser;
 use Symfony\Component\Mime\MimeTypes;
 
@@ -21,6 +22,32 @@ class File
         }
 
         return trim($dirname, '/');
+    }
+
+    /**
+     * Remove any disallowed characters from a directory value.
+     * @param  string $path
+     * @return string
+     */
+    public static function sanitizePath(string $path): string
+    {
+        return trim(
+            preg_replace('/[^a-zA-Z0-9-_\/.%]+/', '-', Str::ascii($path)),
+            DIRECTORY_SEPARATOR . '-'
+        );
+    }
+
+    /**
+     * Remove any disallowed characters from a filename.
+     * @param  string $file
+     * @return string
+     */
+    public static function sanitizeFileName(string $file): string
+    {
+        return trim(
+            preg_replace('/[^a-zA-Z0-9-_.%]+/', '-', Str::ascii($file)),
+            '-'
+        );
     }
 
     /**
@@ -59,6 +86,10 @@ class File
         }
 
         // fall back to the older ExtensionGuesser class (deprecated since Symfony 4.3)
-        return ExtensionGuesser::getInstance()->guess($mimeType);
+        if (class_exists(ExtensionGuesser::class)) {
+            return ExtensionGuesser::getInstance()->guess($mimeType);
+        }
+
+        return null;
     }
 }

--- a/src/Jobs/CreateImageVariants.php
+++ b/src/Jobs/CreateImageVariants.php
@@ -25,18 +25,24 @@ class CreateImageVariants implements ShouldQueue
     private $model;
 
     /**
+     * @var bool
+     */
+    private $forceRecreate;
+
+    /**
      * CreateImageVariants constructor.
      * @param Media $model
      * @param string|string[] $variantNames
      * @throws ImageManipulationException
      */
-    public function __construct(Media $model, $variantNames)
+    public function __construct(Media $model, $variantNames, bool $forceRecreate = false)
     {
         $variantNames = (array) $variantNames;
         $this->validate($model, $variantNames);
 
         $this->variantNames = $variantNames;
         $this->model = $model;
+        $this->forceRecreate = $forceRecreate;
     }
 
     public function handle()
@@ -44,7 +50,8 @@ class CreateImageVariants implements ShouldQueue
         foreach ($this->getVariantNames() as $variantName) {
             $this->getImageManipulator()->createImageVariant(
                 $this->getModel(),
-                $variantName
+                $variantName,
+                $this->getForceRecreate()
             );
         }
     }
@@ -82,5 +89,13 @@ class CreateImageVariants implements ShouldQueue
     private function getImageManipulator(): ImageManipulator
     {
         return app(ImageManipulator::class);
+    }
+
+    /**
+     * @return bool
+     */
+    public function getForceRecreate(): bool
+    {
+        return $this->forceRecreate;
     }
 }

--- a/src/Media.php
+++ b/src/Media.php
@@ -186,7 +186,11 @@ class Media extends Model
             return $this;
         }
 
-        return $this->originalMedia->variants->first($filter);
+        if ($this->originalMedia) {
+            return $this->originalMedia->variants->first($filter);
+        }
+
+        return null;
     }
 
     public function findOriginal(): Media

--- a/src/MediaMover.php
+++ b/src/MediaMover.php
@@ -6,6 +6,7 @@ namespace Plank\Mediable;
 use Illuminate\Contracts\Filesystem\FileNotFoundException;
 use Illuminate\Filesystem\FilesystemManager;
 use Plank\Mediable\Exceptions\MediaMoveException;
+use Plank\Mediable\Helpers\File;
 
 /**
  * Media Mover Class.
@@ -41,8 +42,7 @@ class MediaMover
         $storage = $this->filesystem->disk($media->disk);
 
         $filename = $this->cleanFilename($media, $filename);
-
-        $directory = trim($directory, '/');
+        $directory = File::sanitizePath($directory);
         $targetPath = $directory . '/' . $filename . '.' . $media->extension;
 
         if ($storage->has($targetPath)) {
@@ -78,7 +78,7 @@ class MediaMover
         $targetStorage = $this->filesystem->disk($disk);
 
         $filename = $this->cleanFilename($media, $filename);
-        $directory = trim($directory, '/');
+        $directory = File::sanitizePath($directory);
         $targetPath = $directory . '/' . $filename . '.' . $media->extension;
 
         if ($targetStorage->has($targetPath)) {
@@ -116,8 +116,8 @@ class MediaMover
         $storage = $this->filesystem->disk($media->disk);
 
         $filename = $this->cleanFilename($media, $filename);
+        $directory = File::sanitizePath($directory);
 
-        $directory = trim($directory, '/');
         $targetPath = $directory . '/' . $filename . '.' . $media->extension;
 
         if ($storage->has($targetPath)) {
@@ -164,7 +164,7 @@ class MediaMover
         $targetStorage = $this->filesystem->disk($disk);
 
         $filename = $this->cleanFilename($media, $filename);
-        $directory = trim($directory, '/');
+        $directory = File::sanitizePath($directory);
         $targetPath = $directory . '/' . $filename . '.' . $media->extension;
 
         if ($targetStorage->has($targetPath)) {
@@ -193,7 +193,9 @@ class MediaMover
     protected function cleanFilename(Media $media, ?string $filename): string
     {
         if ($filename) {
-            return $this->removeExtensionFromFilename($filename, $media->extension);
+            return File::sanitizeFileName(
+                $this->removeExtensionFromFilename($filename, $media->extension)
+            );
         }
 
         return $media->filename;

--- a/src/MediaUploader.php
+++ b/src/MediaUploader.php
@@ -163,7 +163,7 @@ class MediaUploader
      */
     public function toDirectory(string $directory): self
     {
-        $this->directory = trim($this->sanitizePath($directory), DIRECTORY_SEPARATOR);
+        $this->directory = File::sanitizePath($directory);
 
         return $this;
     }
@@ -175,7 +175,7 @@ class MediaUploader
      */
     public function useFilename(string $filename): self
     {
-        $this->filename = $this->sanitizeFilename($filename);
+        $this->filename = File::sanitizeFilename($filename);
         $this->hashFilename = false;
 
         return $this;
@@ -818,7 +818,6 @@ class MediaUploader
         switch ($this->config['on_duplicate'] ?? MediaUploader::ON_DUPLICATE_INCREMENT) {
             case static::ON_DUPLICATE_ERROR:
                 throw FileExistsException::fileExists($model->getDiskPath());
-                break;
             case static::ON_DUPLICATE_REPLACE:
                 $this->deleteExistingMedia($model);
                 break;
@@ -902,7 +901,7 @@ class MediaUploader
             return $this->generateHash();
         }
 
-        return $this->sanitizeFileName($this->source->filename());
+        return File::sanitizeFileName($this->source->filename());
     }
 
     /**
@@ -923,25 +922,7 @@ class MediaUploader
         return hash_final($ctx);
     }
 
-    /**
-     * Remove any disallowed characters from a directory value.
-     * @param  string $path
-     * @return string
-     */
-    private function sanitizePath(string $path): string
-    {
-        return str_replace(['#', '?', '\\'], '-', $path);
-    }
 
-    /**
-     * Remove any disallowed characters from a filename.
-     * @param  string $file
-     * @return string
-     */
-    private function sanitizeFileName(string $file): string
-    {
-        return str_replace(['#', '?', '\\', '/'], '-', $file);
-    }
 
     private function writeToDisk(Media $model): void
     {

--- a/tests/Integration/Helpers/FileTest.php
+++ b/tests/Integration/Helpers/FileTest.php
@@ -27,4 +27,20 @@ class FileTest extends TestCase
     {
         $this->assertEquals('png', File::guessExtension('image/png'));
     }
+
+    public function test_it_sanitizes_filenames()
+    {
+        $this->assertEquals(
+            'hello-world-what-s_new-with.you',
+            File::sanitizeFileName("héllo/world! \\  \t whàt\'ς_new with.you?")
+        );
+    }
+
+    public function test_it_sanitizes_paths()
+    {
+        $this->assertEquals(
+            'hello/world-what-s_new-with.you',
+            File::sanitizePath("/héllo/world! \\  \t whàt\'ς_new with.you??")
+        );
+    }
 }

--- a/tests/Integration/ImageManipulationTest.php
+++ b/tests/Integration/ImageManipulationTest.php
@@ -9,14 +9,14 @@ class ImageManipulationTest extends TestCase
 {
     public function test_can_get_set_manipulation_callback()
     {
-        $callback = $this->getCallback();
+        $callback = $this->getMockCallable();
         $manipulation = new ImageManipulation($callback);
         $this->assertSame($callback, $manipulation->getCallback());
     }
 
     public function test_can_get_set_output_quality()
     {
-        $manipulation = new ImageManipulation($this->getCallback());
+        $manipulation = new ImageManipulation($this->getMockCallable());
         $this->assertEquals(90, $manipulation->getOutputQuality());
         $manipulation->setOutputQuality(-100);
         $this->assertEquals(0, $manipulation->getOutputQuality());
@@ -28,37 +28,82 @@ class ImageManipulationTest extends TestCase
 
     public function test_can_get_set_output_format()
     {
-        $manipulation = new ImageManipulation($this->getCallback());
+        $manipulation = new ImageManipulation($this->getMockCallable());
         $this->assertNull($manipulation->getOutputFormat());
         $manipulation->setOutputFormat('jpg');
         $this->assertEquals('jpg', $manipulation->getOutputFormat());
-        $manipulation->toBmpFormat();
+        $manipulation->outputBmpFormat();
         $this->assertEquals('bmp', $manipulation->getOutputFormat());
-        $manipulation->toGifFormat();
+        $manipulation->outputGifFormat();
         $this->assertEquals('gif', $manipulation->getOutputFormat());
-        $manipulation->toPngFormat();
+        $manipulation->outputPngFormat();
         $this->assertEquals('png', $manipulation->getOutputFormat());
-        $manipulation->toTiffFormat();
+        $manipulation->outputTiffFormat();
         $this->assertEquals('tif', $manipulation->getOutputFormat());
-        $manipulation->toWebpFormat();
+        $manipulation->outputWebpFormat();
         $this->assertEquals('webp', $manipulation->getOutputFormat());
-        $manipulation->toJpegFormat();
+        $manipulation->outputJpegFormat();
         $this->assertEquals('jpg', $manipulation->getOutputFormat());
     }
 
     public function test_can_get_set_before_save_callback()
     {
-        $callback = $this->getCallback();
-        $manipulation = new ImageManipulation($this->getCallback());
+        $callback = $this->getMockCallable();
+        $manipulation = new ImageManipulation($this->getMockCallable());
 
         $this->assertNull($manipulation->getBeforeSave());
         $manipulation->beforeSave($callback);
         $this->assertSame($callback, $manipulation->getBeforeSave());
     }
 
-    private function getCallback()
+    public function test_destination_setters()
     {
-        return function () {
-        };
+        $manipulation = new ImageManipulation($this->getMockCallable());
+
+        $this->assertNull($manipulation->getDisk());
+        $this->assertNull($manipulation->getDirectory());
+        $this->assertNull($manipulation->getFilename());
+        $this->assertFalse($manipulation->usingHashForFilename());
+
+        $manipulation->toDisk('tmp');
+        $this->assertEquals('tmp', $manipulation->getDisk());
+
+        $manipulation->toDirectory('bar');
+        $this->assertEquals('bar', $manipulation->getDirectory());
+
+        $manipulation->toDestination('uploads', 'bat');
+        $this->assertEquals('uploads', $manipulation->getDisk());
+        $this->assertEquals('bat', $manipulation->getDirectory());
+
+        $manipulation->useFilename('potato');
+        $this->assertEquals('potato', $manipulation->getFilename());
+        $this->assertFalse($manipulation->usingHashForFilename());
+
+        $manipulation->useHashForFilename();
+        $this->assertNull($manipulation->getFilename());
+        $this->assertTrue($manipulation->usingHashForFilename());
+
+        $manipulation->useOriginalFilename();
+        $this->assertNull($manipulation->getFilename());
+        $this->assertFalse($manipulation->usingHashForFilename());
+    }
+
+    public function test_get_duplicate_behaviours()
+    {
+        $manipulation = new ImageManipulation($this->getMockCallable());
+        $this->assertEquals(
+            ImageManipulation::ON_DUPLICATE_INCREMENT,
+            $manipulation->getOnDuplicateBehaviour()
+        );
+        $manipulation->onDuplicateError();
+        $this->assertEquals(
+            ImageManipulation::ON_DUPLICATE_ERROR,
+            $manipulation->getOnDuplicateBehaviour()
+        );
+        $manipulation->onDuplicateIncrement();
+        $this->assertEquals(
+            ImageManipulation::ON_DUPLICATE_INCREMENT,
+            $manipulation->getOnDuplicateBehaviour()
+        );
     }
 }

--- a/tests/Integration/Jobs/CreateImageVariantsTest.php
+++ b/tests/Integration/Jobs/CreateImageVariantsTest.php
@@ -25,10 +25,33 @@ class CreateImageVariantsTest extends TestCase
             ->willReturn($this->createMock(ImageManipulation::class));
         $manipulator->expects($this->exactly(2))
             ->method('createImageVariant')
-            ->withConsecutive([$model, $variant1], [$model, $variant2]);
+            ->withConsecutive([$model, $variant1, false], [$model, $variant2, false]);
         app()->instance(ImageManipulator::class, $manipulator);
 
         $job = new CreateImageVariants($model, [$variant1, $variant2]);
+        $job->handle();
+    }
+
+    public function test_it_will_trigger_image_manipulation_recreate()
+    {
+        $model = $this->makeMedia(['aggregate_type' => 'image']);
+        $variant1 = 'foo';
+        $variant2 = 'bar';
+
+        $manipulator = $this->createMock(ImageManipulator::class);
+        $manipulator->expects($this->once())
+            ->method('validateMedia')
+            ->with($model);
+        $manipulator->expects($this->exactly(2))
+            ->method('getVariantDefinition')
+            ->withConsecutive([$variant1], [$variant2])
+            ->willReturn($this->createMock(ImageManipulation::class));
+        $manipulator->expects($this->exactly(2))
+            ->method('createImageVariant')
+            ->withConsecutive([$model, $variant1, true], [$model, $variant2, true]);
+        app()->instance(ImageManipulator::class, $manipulator);
+
+        $job = new CreateImageVariants($model, [$variant1, $variant2], true);
         $job->handle();
     }
 }


### PR DESCRIPTION
existing variants will not be recreated unless specified

recreating a variant will replace the file and update the existing media record

output destination can now be defined from the ImageManipulation

If a file already exists at the destination, filename will be incremented or error out

filename and directory sanitization now enforces both filesystem and URL safe ASCII characters