### PR TITLE
Update Laravel version support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![StyleCI](https://styleci.io/repos/63791110/shield)](https://styleci.io/repos/63791110)
 [![Packagist](https://img.shields.io/packagist/v/plank/laravel-mediable.svg?style=flat-square)](https://packagist.org/packages/plank/laravel-mediable)
 
-Laravel-Mediable is a package for easily uploading and attaching media files to models with Laravel 5.
+Laravel-Mediable is a package for easily uploading and attaching media files to models with Laravel.
 
 ## Features
 


### PR DESCRIPTION
Just noticed this in passing and figure it might be good to not specify `Laravel 5` explicitly now we are on `8.0` and the current version supports `6.0+`. Probably easier to just let composer tell us which version is supported or introduce a version support table like [Test Bench](https://github.com/orchestral/testbench#version-compatibility) has.

If you'd like a support table, I'm happy to one together in this PR for ya.