### PR TITLE
Fix facade not returning distinct instances

### DIFF
--- a/src/Facades/MediaUploader.php
+++ b/src/Facades/MediaUploader.php
@@ -54,4 +54,13 @@ class MediaUploader extends Facade
     {
         return 'mediable.uploader';
     }
+
+    public static function getFacadeRoot()
+    {
+        // prevent the facade from behaving like a singleton
+        if (!self::isMock()) {
+            self::clearResolvedInstance('mediable.uploader');
+        }
+        return parent::getFacadeRoot();
+    }
 }

--- a/tests/Integration/MediaUploaderTest.php
+++ b/tests/Integration/MediaUploaderTest.php
@@ -29,6 +29,30 @@ class MediaUploaderTest extends TestCase
         $this->assertInstanceOf(MediaUploader::class, Facade::getFacadeRoot());
     }
 
+    public function test_facade_instantiates_unique_instances()
+    {
+        /** @var MediaUploader $uploader1 */
+        $uploader1 = Facade::getFacadeRoot();
+        $uploader1->setAllowedAggregateTypes(['image', 'vector']);
+
+        /** @var MediaUploader $uploader2 */
+        $uploader2 = Facade::getFacadeRoot();
+        $uploader2->setAllowedAggregateTypes(['archive']);
+
+        $config = $this->getPrivateProperty($uploader1, 'config');
+        $config->setAccessible(true);
+        $this->assertNotEquals(
+            $config->getValue($uploader1),
+            $config->getValue($uploader2)
+        );
+    }
+
+    public function test_facade_is_mockable()
+    {
+        Facade::shouldReceive('upload')->once();
+        Facade::upload();
+    }
+
     public function test_it_can_set_on_duplicate_behavior_via_facade()
     {
         $uploader = Facade::onDuplicateError();


### PR DESCRIPTION
Though registered to the container to resolve as discrete instances, Laravel Facades track an implicit singleton. Fix the behaviour by clearing the Facade instance on each load

Fixes #237