### PR TITLE
Added onDuplicateReplaceWithVariants()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 5.1.0 - 2021-04-28
+- Added `MediaUploader::onDuplicateReplaceWithVariants()` which behaves similar to `onDuplicateReplace()` but will also delete any variants of the replaced Media record.
+
+## 5.0.7 - 2020-12-11
+- Fixed `MediaUploader` Facade returning the same instance
+
+## 5.0.6 - 2020-12-05
+- Resolve bugs with PHP 8.0
+
+## 5.0.5 - 2020-12-05
+- `ImageManipulator` now uses `$media->contents()` instead of `$media->stream()`, as Intervention Image loads the whole file into memory anyways, and the former seems to have fewer hiccups for various cloud filesystems.
+
 ## 5.0.4 - 2020-12-02
 - Fixed serialization of `CreateImageVariants` job.
 

--- a/docs/source/uploader.rst
+++ b/docs/source/uploader.rst
@@ -87,6 +87,10 @@ Occasionally, a file with a matching name might already exist at the destination
     // replace old file and media record with new ones, break associations
     $uploader->onDuplicateReplace();
 
+    // replace old file and media record with new ones, break associations
+    // will also delete any existing variants of the replaced media record
+    $uploader->onDuplicateReplaceWithVariants();
+
     // cancel upload, throw an exception
     $uploader->onDuplicateError();
 

--- a/src/Facades/MediaUploader.php
+++ b/src/Facades/MediaUploader.php
@@ -25,6 +25,7 @@ use Plank\Mediable\MediaUploader as Uploader;
  * @method static Uploader onDuplicateError()
  * @method static Uploader onDuplicateIncrement()
  * @method static Uploader onDuplicateReplace()
+ * @method static Uploader onDuplicateReplaceWithVariants()
  * @method static Uploader onDuplicateUpdate()
  * @method static Uploader setStrictTypeChecking($strict)
  * @method static Uploader setAllowUnrecognizedTypes($allow)

--- a/src/Media.php
+++ b/src/Media.php
@@ -13,6 +13,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
 use Illuminate\Database\Eloquent\Relations\Pivot;
 use Illuminate\Database\Eloquent\SoftDeletingScope;
+use Illuminate\Support\Arr;
 use Plank\Mediable\Exceptions\MediaMoveException;
 use Plank\Mediable\Exceptions\MediaUrlException;
 use Plank\Mediable\Helpers\File;


### PR DESCRIPTION
behaves similar to  but will also delete any variants of the replaced Media record.