### PR TITLE
Publish migrations

### DIFF
--- a/src/MediableServiceProvider.php
+++ b/src/MediableServiceProvider.php
@@ -35,8 +35,8 @@ class MediableServiceProvider extends ServiceProvider
         );
         
         $this->publishes([
-            __DIR__.'/../database/migrations' => $this->app->databasePath('migrations'),
-        ], 'migrations');
+            __DIR__.'/../migrations' => $this->app->databasePath('migrations'),
+        ], 'mediable-migrations');
 
         $this->loadMigrationsFrom($root . '/migrations');
     }

--- a/src/MediableServiceProvider.php
+++ b/src/MediableServiceProvider.php
@@ -33,6 +33,10 @@ class MediableServiceProvider extends ServiceProvider
             ],
             'config'
         );
+        
+        $this->publishes([
+            __DIR__.'/../database/migrations' => $this->app->databasePath('migrations'),
+        ], 'migrations');
 
         $this->loadMigrationsFrom($root . '/migrations');
     }


### PR DESCRIPTION
This change will copy migrations to the project when using artisan vendor:publish. Allowing them to be customized.