### PR TITLE
Changes to suport foreignId()'s reliance on unsignedBigInteger

### DIFF
--- a/migrations/2016_06_27_000000_create_mediable_tables.php
+++ b/migrations/2016_06_27_000000_create_mediable_tables.php
@@ -37,7 +37,7 @@ class CreateMediableTables extends Migration
             Schema::create(
                 'mediables',
                 function (Blueprint $table) {
-                    $table->integer('media_id')->unsigned();
+                    $table->unsignedBigInteger('media_id');
                     $table->string('mediable_type');
                     $table->integer('mediable_id')->unsigned();
                     $table->string('tag');

--- a/migrations/2020_10_12_000000_add_variants_to_media.php
+++ b/migrations/2020_10_12_000000_add_variants_to_media.php
@@ -20,8 +20,7 @@ class AddVariantsToMedia extends Migration
                 $table->string('variant_name', 255)
                     ->after('size')
                     ->nullable();
-                $table->integer('original_media_id')
-                    ->unsigned()
+                $table->unsignedBigInteger('original_media_id')
                     ->after('variant_name')
                     ->nullable();
 


### PR DESCRIPTION
Migration was failing with unsigned integer definition for foreign key. It might be better to use `foreignId()` instead of the more verbose `foreign()->references()->on()` syntax, but this was the smallest changeset that fixes migration for me.