### PR TITLE
Prevent duplicated migration and publish as migration with current time

### DIFF
--- a/config/mediable.php
+++ b/config/mediable.php
@@ -237,4 +237,11 @@ return [
      * Detach associated media when mediable model is soft deleted.
      */
     'detach_on_soft_delete' => false,
+
+    /**
+     * Prevents loading migrations from the package.
+     *
+     * Use this if you are renaming the published migrations and want to prevent them from being loaded twice.
+     */
+    'ignore_migrations' => false,
 ];

--- a/src/MediableServiceProvider.php
+++ b/src/MediableServiceProvider.php
@@ -26,6 +26,10 @@ class MediableServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
+        if (!$this->app->runningInConsole()) {
+            return;
+        }
+
         $root = dirname(__DIR__);
         $this->publishes(
             [
@@ -41,7 +45,9 @@ class MediableServiceProvider extends ServiceProvider
             $this->publishes([
                 $root . '/migrations/2020_10_12_000000_add_variants_to_media.php' => $this->app->databasePath('migrations/'.date('Y_m_d_His', time() + 1).'_add_variants_to_media.php'),
             ], 'mediable-migrations');
+        }
 
+        if (!config('mediable.ignore_migrations', false)) {
             $this->loadMigrationsFrom($root . '/migrations');
         }
     }

--- a/src/MediableServiceProvider.php
+++ b/src/MediableServiceProvider.php
@@ -33,12 +33,17 @@ class MediableServiceProvider extends ServiceProvider
             ],
             'config'
         );
-        
-        $this->publishes([
-            __DIR__.'/../migrations' => $this->app->databasePath('migrations'),
-        ], 'mediable-migrations');
 
-        $this->loadMigrationsFrom($root . '/migrations');
+        if (empty(glob($this->app->databasePath('migrations/*_create_mediable_tables.php'))) && empty(glob($this->app->databasePath('migrations/*_add_variants_to_media.php')))) {
+            $this->publishes([
+                $root . '/migrations/2016_06_27_000000_create_mediable_tables.php' => $this->app->databasePath('migrations/'.date('Y_m_d_His', time()).'_create_mediable_tables.php'),
+            ], 'mediable-migrations');
+            $this->publishes([
+                $root . '/migrations/2020_10_12_000000_add_variants_to_media.php' => $this->app->databasePath('migrations/'.date('Y_m_d_His', time() + 1).'_add_variants_to_media.php'),
+            ], 'mediable-migrations');
+
+            $this->loadMigrationsFrom($root . '/migrations');
+        }
     }
 
     /**


### PR DESCRIPTION
This PR tries to solve the following two problems in a backwards compatible way:

- Currently publishing the migrations can lead to `Cannot declare class AddVariantsToMedia, because the name is already in use` when changing the timestamp of the migration files because both the package and the published migration files are going to be loaded. 
- The migration files have a fixed timestamp. I ran into the issue that I already had an earlier media table, which I wanted to rename to `media_old` but since the migration files of the package have old fixed timestamps and cannot be overwritten due to the previous mentioned error, my "rename Migration" could not run before the package migration.




