### PR TITLE
update psr/http-message requirement to allow v1 or v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "illuminate/filesystem": "^8.83.3|^9.0|^10.0",
         "illuminate/database": "^8.83.3|^9.0|^10.0",
         "league/flysystem": "^1.1.9|^2.4.2|^3.0.4",
-        "psr/http-message": "^2.0",
+        "psr/http-message": "^1.0|^2.0",
         "intervention/image": "^2.7.1",
         "guzzlehttp/guzzle": "^6.5.5|^7.4.1",
         "symfony/http-foundation": "^5.0.11|^6.0.3"


### PR DESCRIPTION
https://github.com/plank/laravel-mediable/pull/318 bumped the requirement to a hard v2 which is causing issues with other packages that require v1.

Could it be considered to allow the proposed `^1.0|^2.0` was there any hard requirement for `v2` or just a housekeeping change?