### PR TITLE
Take visibility value from filesystem config

### DIFF
--- a/src/MediaUploader.php
+++ b/src/MediaUploader.php
@@ -1013,6 +1013,9 @@ class MediaUploader
     {
         $options = $this->options;
         if (!isset($options['visibility'])) {
+            $options['visibility'] = config('filesystems.disks.'.$this->disk.'options.visibility') ?? null;
+        }
+        if (!isset($options['visibility'])) {
             $options['visibility'] = $this->visibility;
         }
         return $options;


### PR DESCRIPTION
Take visibility value from filesystem config, if defined, if not default to public.

A fix for https://github.com/plank/laravel-mediable/issues/239#issuecomment-745009033

This was also the reason for issue reported in https://github.com/plank/laravel-mediable/issues/173#issue-593553429