### PR TITLE
alt attribute should default to null in Media model

### DIFF
--- a/src/Media.php
+++ b/src/Media.php
@@ -86,7 +86,7 @@ class Media extends Model
     ];
 
     protected $attributes = [
-        'alt' => ''
+        'alt' => null
     ];
 
     /**


### PR DESCRIPTION
The recently added `alt` column's default empty string value means that new records will always include the `alt` column as a value to insert (e.g.

```SQL
INSERT INTO `media`
(`alt`, `disk`, `filename`, `extension`, `mime_type`, `updated_at`, `created_at`)
values
('', 'public', 'example', 'png', 'image/png', '2024-01-01 00:00:00',  '2024-01-01 00:00:00')
```

In addition to creating more verbose queries and slightly larger records on disk, this will break when using Spatie's [Laravel Translatable](https://spatie.be/docs/laravel-translatable/v6/introduction) package if, as is recommended, the column type is changed to `JSON` which still stores the value as `LONGTEXT` but adds a constraint of `json_valid(alt)` which will accept `null` but not an empty string.