### PR TITLE
PHP 8.4 deprecates implicit nullable types. This PR fixes the depreca…

### DIFF
--- a/src/Exceptions/MediaUpload/ConfigurationException.php
+++ b/src/Exceptions/MediaUpload/ConfigurationException.php
@@ -33,7 +33,7 @@ class ConfigurationException extends MediaUploadException
         return new self("Could not recognize source, `{$source}` provided.");
     }
 
-    public static function invalidSource(string $message, \Throwable $original = null): self
+    public static function invalidSource(string $message, ?\Throwable $original): self
     {
         return new self("Invalid source provided. {$message}", 0, $original);
     }

--- a/src/Exceptions/MediaUpload/ConfigurationException.php
+++ b/src/Exceptions/MediaUpload/ConfigurationException.php
@@ -33,7 +33,7 @@ class ConfigurationException extends MediaUploadException
         return new self("Could not recognize source, `{$source}` provided.");
     }
 
-    public static function invalidSource(string $message, ?\Throwable $original): self
+    public static function invalidSource(string $message, ?\Throwable $original= null): self
     {
         return new self("Invalid source provided. {$message}", 0, $original);
     }

--- a/src/Exceptions/MediaUpload/FileNotFoundException.php
+++ b/src/Exceptions/MediaUpload/FileNotFoundException.php
@@ -7,7 +7,7 @@ use Plank\Mediable\Exceptions\MediaUploadException;
 
 class FileNotFoundException extends MediaUploadException
 {
-    public static function fileNotFound(string $path, ?\Throwable $original): self
+    public static function fileNotFound(string $path, ?\Throwable $original = null): self
     {
         return new self("File `{$path}` does not exist.", 0, $original);
     }

--- a/src/Exceptions/MediaUpload/FileNotFoundException.php
+++ b/src/Exceptions/MediaUpload/FileNotFoundException.php
@@ -7,7 +7,7 @@ use Plank\Mediable\Exceptions\MediaUploadException;
 
 class FileNotFoundException extends MediaUploadException
 {
-    public static function fileNotFound(string $path, \Throwable $original = null): self
+    public static function fileNotFound(string $path, ?\Throwable $original): self
     {
         return new self("File `{$path}` does not exist.", 0, $original);
     }

--- a/src/Helpers/File.php
+++ b/src/Helpers/File.php
@@ -30,7 +30,7 @@ class File
      * @param  string $path
      * @return string
      */
-    public static function sanitizePath(string $path, ?string $language): string
+    public static function sanitizePath(string $path, ?string $language = null): string
     {
         $language = $language ?: App::currentLocale();
         return trim(
@@ -48,7 +48,7 @@ class File
      * @param  string $file
      * @return string
      */
-    public static function sanitizeFileName(string $file, ?string $language): string
+    public static function sanitizeFileName(string $file, ?string $language = null): string
     {
         $language = $language ?: App::currentLocale();
         return trim(

--- a/src/Helpers/File.php
+++ b/src/Helpers/File.php
@@ -30,7 +30,7 @@ class File
      * @param  string $path
      * @return string
      */
-    public static function sanitizePath(string $path, string $language = null): string
+    public static function sanitizePath(string $path, ?string $language): string
     {
         $language = $language ?: App::currentLocale();
         return trim(
@@ -48,7 +48,7 @@ class File
      * @param  string $file
      * @return string
      */
-    public static function sanitizeFileName(string $file, string $language = null): string
+    public static function sanitizeFileName(string $file, ?string $language): string
     {
         $language = $language ?: App::currentLocale();
         return trim(

--- a/src/Media.php
+++ b/src/Media.php
@@ -47,7 +47,7 @@ use Psr\Http\Message\StreamInterface;
  * @method static Builder forPathOnDisk(string $disk, string $path)
  * @method static Builder unordered()
  * @method static Builder whereIsOriginal()
- * @method static Builder whereIsVariant(string $variant_name = null)
+ * @method static Builder whereIsVariant(?string $variant_name)
  */
 class Media extends Model
 {
@@ -305,7 +305,7 @@ class Media extends Model
         $q->whereNull('original_media_id');
     }
 
-    public function scopeWhereIsVariant(Builder $q, string $variant_name = null): void
+    public function scopeWhereIsVariant(Builder $q, ?string $variant_name): void
     {
         $q->whereNotNull('original_media_id');
         if ($variant_name) {
@@ -431,7 +431,7 @@ class Media extends Model
      * @param string|null $variantName if specified, will check if the model if a specific kind of variant
      * @return bool
      */
-    public function isVariant(string $variantName = null): bool
+    public function isVariant(?string $variantName): bool
     {
         return $this->original_media_id !== null
             && (!$variantName || $this->variant_name === $variantName);
@@ -482,7 +482,7 @@ class Media extends Model
      * @return void
      * @throws MediaMoveException
      */
-    public function move(string $destination, string $filename = null): void
+    public function move(string $destination, ?string $filename): void
     {
         $this->getMediaMover()->move($this, $destination, $filename);
     }
@@ -507,7 +507,7 @@ class Media extends Model
      * @return Media
      * @throws MediaMoveException
      */
-    public function copyTo(string $destination, string $filename = null): self
+    public function copyTo(string $destination, ?string $filename): self
     {
         return $this->getMediaMover()->copyTo($this, $destination, $filename);
     }
@@ -525,7 +525,7 @@ class Media extends Model
     public function moveToDisk(
         string $disk,
         string $destination,
-        string $filename = null,
+        ?string $filename,
         array $options = []
     ): void {
         $this->getMediaMover()
@@ -547,7 +547,7 @@ class Media extends Model
     public function copyToDisk(
         string $disk,
         string $destination,
-        string $filename = null,
+        ?string $filename,
         array $options = []
     ): self {
         return $this->getMediaMover()

--- a/src/Media.php
+++ b/src/Media.php
@@ -47,7 +47,7 @@ use Psr\Http\Message\StreamInterface;
  * @method static Builder forPathOnDisk(string $disk, string $path)
  * @method static Builder unordered()
  * @method static Builder whereIsOriginal()
- * @method static Builder whereIsVariant(?string $variant_name)
+ * @method static Builder whereIsVariant(?string $variant_name = null)
  */
 class Media extends Model
 {
@@ -305,7 +305,7 @@ class Media extends Model
         $q->whereNull('original_media_id');
     }
 
-    public function scopeWhereIsVariant(Builder $q, ?string $variant_name): void
+    public function scopeWhereIsVariant(Builder $q, ?string $variant_name = null): void
     {
         $q->whereNotNull('original_media_id');
         if ($variant_name) {
@@ -431,7 +431,7 @@ class Media extends Model
      * @param string|null $variantName if specified, will check if the model if a specific kind of variant
      * @return bool
      */
-    public function isVariant(?string $variantName): bool
+    public function isVariant(?string $variantName = null): bool
     {
         return $this->original_media_id !== null
             && (!$variantName || $this->variant_name === $variantName);
@@ -482,7 +482,7 @@ class Media extends Model
      * @return void
      * @throws MediaMoveException
      */
-    public function move(string $destination, ?string $filename): void
+    public function move(string $destination, ?string $filename = null): void
     {
         $this->getMediaMover()->move($this, $destination, $filename);
     }
@@ -507,7 +507,7 @@ class Media extends Model
      * @return Media
      * @throws MediaMoveException
      */
-    public function copyTo(string $destination, ?string $filename): self
+    public function copyTo(string $destination, ?string $filename = null): self
     {
         return $this->getMediaMover()->copyTo($this, $destination, $filename);
     }
@@ -525,7 +525,7 @@ class Media extends Model
     public function moveToDisk(
         string $disk,
         string $destination,
-        ?string $filename,
+        ?string $filename = null,
         array $options = []
     ): void {
         $this->getMediaMover()
@@ -547,7 +547,7 @@ class Media extends Model
     public function copyToDisk(
         string $disk,
         string $destination,
-        ?string $filename,
+        ?string $filename = null,
         array $options = []
     ): self {
         return $this->getMediaMover()

--- a/src/MediaMover.php
+++ b/src/MediaMover.php
@@ -30,7 +30,7 @@ class MediaMover
      * @return void
      * @throws MediaMoveException If attempting to change the file extension or a file with the same name already exists at the destination
      */
-    public function move(Media $media, string $directory, ?string $filename): void
+    public function move(Media $media, string $directory, ?string $filename = null): void
     {
         $storage = $this->filesystem->disk($media->disk);
 
@@ -65,7 +65,7 @@ class MediaMover
         Media $media,
         string $disk,
         string $directory,
-        ?string $filename,
+        ?string $filename = null,
         array $options = []
     ): void {
         if ($media->disk === $disk) {
@@ -113,7 +113,7 @@ class MediaMover
      * @return Media
      * @throws MediaMoveException If a file with the same name already exists at the destination or it fails to copy the file
      */
-    public function copyTo(Media $media, string $directory, ?string $filename): Media
+    public function copyTo(Media $media, string $directory, ?string $filename = null): Media
     {
         $storage = $this->filesystem->disk($media->disk);
 
@@ -160,7 +160,7 @@ class MediaMover
         Media $media,
         string $disk,
         string $directory,
-        ?string $filename,
+        ?string $filename = null,
         array $options = []
     ): Media {
         if ($media->disk === $disk) {

--- a/src/MediaMover.php
+++ b/src/MediaMover.php
@@ -30,7 +30,7 @@ class MediaMover
      * @return void
      * @throws MediaMoveException If attempting to change the file extension or a file with the same name already exists at the destination
      */
-    public function move(Media $media, string $directory, string $filename = null): void
+    public function move(Media $media, string $directory, ?string $filename): void
     {
         $storage = $this->filesystem->disk($media->disk);
 
@@ -65,7 +65,7 @@ class MediaMover
         Media $media,
         string $disk,
         string $directory,
-        string $filename = null,
+        ?string $filename,
         array $options = []
     ): void {
         if ($media->disk === $disk) {
@@ -113,7 +113,7 @@ class MediaMover
      * @return Media
      * @throws MediaMoveException If a file with the same name already exists at the destination or it fails to copy the file
      */
-    public function copyTo(Media $media, string $directory, string $filename = null): Media
+    public function copyTo(Media $media, string $directory, ?string $filename): Media
     {
         $storage = $this->filesystem->disk($media->disk);
 
@@ -160,7 +160,7 @@ class MediaMover
         Media $media,
         string $disk,
         string $directory,
-        string $filename = null,
+        ?string $filename,
         array $options = []
     ): Media {
         if ($media->disk === $disk) {

--- a/src/MediaUploader.php
+++ b/src/MediaUploader.php
@@ -88,7 +88,7 @@ class MediaUploader
         FileSystemManager $filesystem,
         SourceAdapterFactory $factory,
         ImageManipulator $imageManipulator,
-        ?array $config
+        ?array $config = null
     ) {
         $this->filesystem = $filesystem;
         $this->factory = $factory;

--- a/src/MediaUploader.php
+++ b/src/MediaUploader.php
@@ -88,7 +88,7 @@ class MediaUploader
         FileSystemManager $filesystem,
         SourceAdapterFactory $factory,
         ImageManipulator $imageManipulator,
-        array $config = null
+        ?array $config
     ) {
         $this->filesystem = $filesystem;
         $this->factory = $factory;

--- a/tests/Integration/UrlGenerators/LocalUrlGeneratorTest.php
+++ b/tests/Integration/UrlGenerators/LocalUrlGeneratorTest.php
@@ -86,7 +86,7 @@ class LocalUrlGeneratorTest extends TestCase
 
     protected function setupGenerator(
         $disk = 'uploads',
-        bool $public = null
+        ?bool $public
     ): LocalUrlGenerator {
         /** @var Media $media */
         $media = factory(Media::class)->make(

--- a/tests/Integration/UrlGenerators/LocalUrlGeneratorTest.php
+++ b/tests/Integration/UrlGenerators/LocalUrlGeneratorTest.php
@@ -86,7 +86,7 @@ class LocalUrlGeneratorTest extends TestCase
 
     protected function setupGenerator(
         $disk = 'uploads',
-        ?bool $public
+        ?bool $public = null
     ): LocalUrlGenerator {
         /** @var Media $media */
         $media = factory(Media::class)->make(


### PR DESCRIPTION
…tion warnings in the package.

PHP 8.4 RC1 releast notes: https://github.com/php/php-src/blob/php-8.4.0RC1/UPGRADING#L497
  . Implicitly nullable parameter types are now deprecated.
    RFC: https://wiki.php.net/rfc/deprecate-implicitly-nullable-types