### PR TITLE
fix null directory

### DIFF
--- a/src/MediaUploader.php
+++ b/src/MediaUploader.php
@@ -46,7 +46,7 @@ class MediaUploader
     /**
      * Path relative to the filesystem disk root.
      */
-    private ?string $directory = null;
+    private string $directory = '';
 
     /**
      * Name of the new file.


### PR DESCRIPTION
This PR fixes bug added in [this commit](https://github.com/plank/laravel-mediable/commit/18c5f8a0554f1fa1e908c1e43fa591e53baca21c#diff-7b65214fdb5be75fb28844d47f1ef5eea6c224cf6736990e8988245e25d0fd0cR47) which causes uploads without directory specified to fail since directory is not nullable.