### PR TITLE
Update 2020_10_12_000000_add_variants_to_media.php

### DIFF
--- a/migrations/2020_10_12_000000_add_variants_to_media.php
+++ b/migrations/2020_10_12_000000_add_variants_to_media.php
@@ -51,8 +51,7 @@ return new class extends Migration {
                 // skip removing this column, the `whenTableDoesntHaveColumn`
                 // method should make this safe to play back
                 if (DB::getDriverName() !== 'sqlite') {
-                    $table->dropForeign('original_media_id');
-                    $table->dropColumn('original_media_id');
+                    $table->dropConstrainedForeignId('original_media_id');
                 }
             }
         );


### PR DESCRIPTION
The `$table->dropConstrainedForeignId('original_media_id')` indicates that the given column and foreign key should be dropped.

Related issues:
- https://github.com/plank/laravel-mediable/issues/364#issue-2613804471
- https://github.com/plank/laravel-mediable/issues/356#issue-2331413021