### PR TITLE
Don't require CLI to execute migrations

### DIFF
--- a/src/MediableServiceProvider.php
+++ b/src/MediableServiceProvider.php
@@ -28,10 +28,6 @@ class MediableServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        if (!$this->app->runningInConsole()) {
-            return;
-        }
-
         $root = dirname(__DIR__);
         $this->publishes(
             [


### PR DESCRIPTION
It's possible to use Artisan::call('migrate:fresh') in non-CLI contexts in general. In my opinion, the plank/laravel-mediable migrations should not be skipped.