### PR TITLE
Add support for intervention/image:4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "illuminate/database": "^12.0|^13.0",
         "illuminate/filesystem": "^12.0|^13.0",
         "illuminate/support": "^12.0|^13.0",
-        "intervention/image": "^2.7.1|^3.9.1",
+        "intervention/image": "^3.9.1|^4.0",
         "league/flysystem": "^3.29.1",
         "symfony/http-foundation": "^6.0.3|^7.2",
         "symfony/mime": "^6.0|^7.2",

--- a/src/ImageManipulation.php
+++ b/src/ImageManipulation.php
@@ -44,7 +44,9 @@ class ImageManipulation
 
     private ?string $outputFormat = null;
 
-    private int $outputQuality = 90;
+    private ?int $outputQuality = null;
+
+    private array $outputOptions = [];
 
     private ?string $disk = null;
 
@@ -89,8 +91,9 @@ class ImageManipulation
 
     /**
      * @return int
+     * @deprecated use getOutputOptions() instead and check for the 'quality' key. Output quality is not supported by all encoders and may be ignored depending on the output format and encoders used.
      */
-    public function getOutputQuality(): int
+    public function getOutputQuality(): ?int
     {
         return $this->outputQuality;
     }
@@ -98,6 +101,7 @@ class ImageManipulation
     /**
      * @param int $outputQuality
      * @return $this
+     * @deprecated use setOutputOptions() instead with the appropriate options for the encoder you are using. Output quality is not supported by all encoders and may be ignored depending on the output format and encoders used.
      */
     public function setOutputQuality(int $outputQuality): self
     {
@@ -112,6 +116,21 @@ class ImageManipulation
     public function getOutputFormat(): ?string
     {
         return $this->outputFormat;
+    }
+
+    /**
+     * Get the options to be passed to the encoder when saving the image.
+     * The options may vary depending on the output format and encoders used.
+     *
+     * @return array
+     */
+    public function getOutputOptions(): array
+    {
+        $options = $this->outputOptions;
+        if ($this->outputQuality !== null) {
+            $options['quality'] = $this->outputQuality;
+        }
+        return $options;
     }
 
     /**
@@ -189,6 +208,16 @@ class ImageManipulation
     {
         $this->setOutputFormat(self::FORMAT_HEIC);
 
+        return $this;
+    }
+
+    /**
+     * @param array $options The options to be passed to the encoder when saving the image. The options may vary depending on the output format and encoders used.
+     * @return $this
+     */
+    public function setOutputOptions(array $options): self
+    {
+        $this->outputOptions = $options;
         return $this;
     }
 

--- a/src/ImageManipulator.php
+++ b/src/ImageManipulator.php
@@ -6,6 +6,7 @@ use GuzzleHttp\Psr7\Utils;
 use Illuminate\Filesystem\FilesystemManager;
 use Illuminate\Support\Collection;
 use Intervention\Image\Commands\StreamCommand;
+use Intervention\Image\Format;
 use Intervention\Image\Image;
 use Intervention\Image\ImageManager;
 use Plank\Mediable\Exceptions\ImageManipulationException;
@@ -137,12 +138,12 @@ class ImageManipulator
         $manipulation = $this->getVariantDefinition($variantName);
 
         $outputFormat = $this->determineOutputFormat($manipulation, $media);
-        if (method_exists($this->imageManager, 'read')) {
-            // Intervention Image  >=3.0
-            $image = $this->imageManager->read($media->contents());
+        if (method_exists($this->imageManager, 'decode')) {
+            // Intervention Image  >=4.0
+            $image = $this->imageManager->decode($media->contents());
         } else {
-            // Intervention Image <3.0
-            $image = $this->imageManager->make($media->contents());
+            // Intervention Image ~3.0
+            $image = $this->imageManager->read($media->contents());
         }
 
         $callback = $manipulation->getCallback();
@@ -151,7 +152,7 @@ class ImageManipulator
         $outputStream = $this->imageToStream(
             $image,
             $outputFormat,
-            $manipulation->getOutputQuality()
+            $manipulation->getOutputOptions()
         );
 
         if ($manipulation->shouldOptimize()) {
@@ -230,12 +231,12 @@ class ImageManipulator
         }
 
         $outputFormat = $this->determineOutputFormat($manipulation, $media);
-        if (method_exists($this->imageManager, 'read')) {
-            // Intervention Image  >=3.0
-            $image = $this->imageManager->read($source->getStream()->getContents());
+        if (method_exists($this->imageManager, 'decode')) {
+            // Intervention Image  >=4.0
+            $image = $this->imageManager->decode($source->getStream()->getContents());
         } else {
-            // Intervention Image <3.0
-            $image = $this->imageManager->make($source->getStream()->getContents());
+            // Intervention Image ~3.0
+            $image = $this->imageManager->read($source->getStream()->getContents());
         }
 
         $callback = $manipulation->getCallback();
@@ -244,7 +245,7 @@ class ImageManipulator
         $outputStream = $this->imageToStream(
             $image,
             $outputFormat,
-            $manipulation->getOutputQuality()
+            $manipulation->getOutputOptions()
         );
 
         if ($manipulation->shouldOptimize()) {
@@ -395,25 +396,38 @@ class ImageManipulator
     private function imageToStream(
         Image $image,
         string $outputFormat,
-        int $outputQuality
+        array $outputOptions
     ) {
-        if (class_exists(StreamCommand::class)) {
-            // Intervention Image  <3.0
-            return $image->stream(
-                $outputFormat,
-                $outputQuality
-            );
-        }
+        if (method_exists($image, 'encodeUsingFormat')) {
+            // Intervention Image  >=4.0
 
-        $formatted = match ($outputFormat) {
-            ImageManipulation::FORMAT_JPG => $image->toJpeg($outputQuality),
-            ImageManipulation::FORMAT_PNG => $image->toPng(),
-            ImageManipulation::FORMAT_GIF => $image->toGif(),
-            ImageManipulation::FORMAT_WEBP => $image->toWebp($outputQuality),
-            ImageManipulation::FORMAT_TIFF => $image->toTiff($outputQuality),
-            ImageManipulation::FORMAT_HEIC => $image->toHeic($outputQuality),
-            default => throw ImageManipulationException::unknownOutputFormat(),
-        };
-        return Utils::streamFor($formatted->toFilePointer());
+            $formatted = $image->encodeUsingFormat(
+                match ($outputFormat) {
+                    ImageManipulation::FORMAT_JPG => Format::JPEG,
+                    ImageManipulation::FORMAT_PNG => Format::PNG,
+                    ImageManipulation::FORMAT_GIF => Format::GIF,
+                    ImageManipulation::FORMAT_WEBP => Format::WEBP,
+                    ImageManipulation::FORMAT_TIFF => Format::TIFF,
+                    ImageManipulation::FORMAT_HEIC => Format::HEIC,
+                    default => throw ImageManipulationException::unknownOutputFormat(),
+                },
+                ...$outputOptions
+            );
+            return Utils::streamFor($formatted->toStream());
+        } else {
+            // Intervention Image <4.0
+            $outputQuality = $outputOptions['quality'] ?? 90;
+
+            $formatted = match ($outputFormat) {
+                ImageManipulation::FORMAT_JPG => $image->toJpeg($outputQuality),
+                ImageManipulation::FORMAT_PNG => $image->toPng(),
+                ImageManipulation::FORMAT_GIF => $image->toGif(),
+                ImageManipulation::FORMAT_WEBP => $image->toWebp($outputQuality),
+                ImageManipulation::FORMAT_TIFF => $image->toTiff($outputQuality),
+                ImageManipulation::FORMAT_HEIC => $image->toHeic($outputQuality),
+                default => throw ImageManipulationException::unknownOutputFormat(),
+            };
+            return Utils::streamFor($formatted->toFilePointer());
+        }
     }
 }

--- a/tests/Integration/ImageManipulationTest.php
+++ b/tests/Integration/ImageManipulationTest.php
@@ -21,7 +21,7 @@ class ImageManipulationTest extends TestCase
     public function test_can_get_set_output_quality(): void
     {
         $manipulation = new ImageManipulation($this->getMockCallable());
-        $this->assertEquals(90, $manipulation->getOutputQuality());
+        $this->assertSame(null, $manipulation->getOutputQuality());
         $manipulation->setOutputQuality(-100);
         $this->assertEquals(0, $manipulation->getOutputQuality());
         $manipulation->setOutputQuality(500);


### PR DESCRIPTION
- Add support for intervention/image:4.0
- drop support for intervention/image:~2.0
- Added `ImageManipulation::setOutputOptions()`, to support various intervention/image output format settings
- Deprecated `ImageManipulation::setOutputQuality()`. Use the `'quality'` key in setOutputOptions() instead