### PR TITLE
Fix undefined array key error in inferAggregateType

### DIFF
--- a/src/MediaUploader.php
+++ b/src/MediaUploader.php
@@ -520,7 +520,7 @@ class MediaUploader
         }
 
         if (count($intersection)) {
-            $type = $intersection[0];
+            $type = reset($intersection);
         } elseif (empty($typesForMime) && empty($typesForExtension)) {
             if (!$this->config['allow_unrecognized_types'] ?? false) {
                 throw FileNotSupportedException::unrecognizedFileType($mimeType, $extension);


### PR DESCRIPTION
I ran into an `Undefined array key 0` exception when using `setAllowedAggregateTypes`. This happens if your allowed type shares a MIME type or extension with another type defined earlier in the config.

The issue is that `array_intersect` preserves original array keys. If the matched type was sitting at index 1 instead of 0, calling `$intersection[0]` on line 523 causes a crash.

This PR just changes `$intersection[0]` to `reset($intersection)` to safely grab the first matched element regardless of its key. This also matches the logic already being used a few lines down for the `array_merge` fallback.