### PR TITLE
apply remote URL validation to each redirect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 7.1.0
+
+**This is a security release, upgrading is strongly recommended**
+* Remote URL validation is now applied to each step in a redirect chain to protect against some forms of Server-Side Request Forgery (SSRF) attacks. This behaviour can be disabled by setting the `mediable.validate_remote_url_redirects` config to `false`.
+* Added `mediable.max_remote_url_redirects` config, which limits the number of redirects that will be followed when `mediable.validate_remote_url_redirects` is enabled. If the limit is exceeded, an exception will be thrown.
+* Fix a bug which caused `MediaUploader` to throw an exception when depending on the configured `mediable.default_disk`
+
 ## 7.0.0
 
 **This is a security release, upgrading is strongly recommended**

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
     "require": {
         "php": ">=8.3.0",
         "ext-fileinfo": "*",
+        "ext-curl": "*",
         "guzzlehttp/guzzle": "^7.9.1",
         "guzzlehttp/psr7": "^2.7",
         "illuminate/database": "^12.0|^13.0",

--- a/config/mediable.php
+++ b/config/mediable.php
@@ -136,6 +136,18 @@ return [
     'allowed_remote_schemes' => ['https'],
 
     /*
+     * Whether allowed_remote_hosts, allowed_remote_schemes, and private IP address
+     * validation should be applied to each step of a redirect chain
+     */
+    'validate_remote_url_redirects' => true,
+
+    /*
+     * Maximum number of redirects permitted for remote URLs
+     * Only applied if validate_remote_url_redirects is enabled
+     */
+    'max_remote_url_redirects' => 5,
+
+    /*
      * List of aggregate types recognized by the application
      *
      * Each type should list the MIME types and extensions

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -133,6 +133,18 @@ The `config/mediable.php` offers a number of options for configuring how media u
     'allowed_remote_schemes' => ['https'],
 
     /*
+     * Whether allowed_remote_hosts, allowed_remote_schemes, and private IP address
+     * validation should be applied to each step of a redirect chain
+     */
+    'validate_remote_url_redirects' => true,
+
+    /*
+     * Maximum number of redirects permitted for remote URLs
+     * Only applied if validate_remote_url_redirects is enabled
+     */
+    'max_remote_url_redirects' => 5,
+
+    /*
      * Only allow files matching specific aggregate type(s) to be uploaded
      */
     'allowed_aggregate_types' => [],

--- a/src/SourceAdapters/RemoteUrlAdapter.php
+++ b/src/SourceAdapters/RemoteUrlAdapter.php
@@ -17,7 +17,7 @@ class RemoteUrlAdapter extends StreamAdapter
 
     public function __construct(string $source)
     {
-        $this->validateUrl($source);
+        $this->validateUrl($source, config('mediable.max_remote_url_redirects'));
         $this->url = $source;
         try {
             $resource = Utils::tryFopen($source, 'rb');
@@ -33,7 +33,7 @@ class RemoteUrlAdapter extends StreamAdapter
         );
     }
 
-    private function validateUrl(string $url): void
+    private function validateUrl(string $url, int $maxRedirects): void
     {
         $allowedSchemes = (array) config('mediable.allowed_remote_schemes', ['https']);
         $parsed = parse_url($url);
@@ -53,17 +53,21 @@ class RemoteUrlAdapter extends StreamAdapter
 
         $allowedHosts = (array) config('mediable.allowed_remote_hosts', []);
         if (!empty($allowedHosts)) {
+            $matched = false;
             foreach ($allowedHosts as $allowedHost) {
                 if (fnmatch(strtolower($allowedHost), strtolower($host))) {
-                    return; // Host is allowed, exit validation
+                    $matched = true;
+                    break;
                 }
             }
-            throw ConfigurationException::invalidSource(
-                'Remote URL host is not in the allowlist.'
-            );
+            if (!$matched) {
+                throw ConfigurationException::invalidSource(
+                    'Remote URL host is not in the allowlist.'
+                );
+            }
         } else {
             // If no allowed hosts are specified, automatically prevent private IPs
-            $ip  = gethostbyname($host);
+            $ip = gethostbyname($host);
             $isPublic = filter_var(
                 $ip,
                 FILTER_VALIDATE_IP,
@@ -73,6 +77,42 @@ class RemoteUrlAdapter extends StreamAdapter
                 throw ConfigurationException::invalidSource(
                     'Private IP ranges are not permitted for remote URLs.'
                 );
+            }
+        }
+
+        if (config('mediable.validate_remote_url_redirects', true)) {
+            // Make a header-only request to check for a redirect
+            $ch = curl_init($url);
+            curl_setopt($ch, CURLOPT_NOBODY, true); // HEAD (headers only)
+            curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+            curl_setopt(
+                $ch,
+                CURLOPT_FOLLOWLOCATION,
+                false
+            ); // DO NOT follow automatically
+            curl_setopt($ch, CURLOPT_TIMEOUT, 5);
+            curl_exec($ch);
+
+            $statusCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+            $redirectUrl = curl_getinfo($ch, CURLINFO_REDIRECT_URL);
+            curl_close($ch);
+
+            // Handle redirect codes (301, 302, 303, 307, 308)
+            if ($statusCode >= 300 && $statusCode < 400 && !empty($redirectUrl)) {
+                if ($maxRedirects < 1) {
+                    throw ConfigurationException::invalidSource(
+                        'Too many redirects for a remote URL.'
+                    );
+                }
+                // Resolve relative paths if the redirect header isn't an absolute URL
+                if (!str_contains($redirectUrl, '://')) {
+                    $parts = parse_url($url);
+                    $redirectUrl = $parts['scheme'] . '://' . $parts['host'] . '/' . ltrim(
+                        $redirectUrl,
+                        '/'
+                    );
+                }
+                $this->validateUrl($redirectUrl, $maxRedirects - 1);
             }
         }
     }

--- a/tests/Integration/SourceAdapters/RemoteUrlAdapterTest.php
+++ b/tests/Integration/SourceAdapters/RemoteUrlAdapterTest.php
@@ -103,4 +103,35 @@ class RemoteUrlAdapterTest extends TestCase
 
         new RemoteUrlAdapter($privateHost);
     }
+
+    public function test_it_validates_hostname_on_redirects()
+    {
+        $this->expectException(ConfigurationException::class);
+        $this->expectExceptionMessage(
+            'Remote URL host is not in the allowlist.'
+        );
+        config()->set('mediable.max_remote_url_redirects', 1);
+        config()->set('mediable.allowed_remote_hosts', ['httpbin.org']);
+        new RemoteUrlAdapter('https://httpbin.org/redirect-to?url=https://evil.com/foo');
+    }
+
+    public function test_it_validates_ip_range_on_redirects()
+    {
+        $this->expectException(ConfigurationException::class);
+        $this->expectExceptionMessage(
+            'Private IP ranges are not permitted for remote URLs.'
+        );
+        config()->set('mediable.max_remote_url_redirects', 1);
+        new RemoteUrlAdapter('https://httpbin.org/redirect-to?url=https://localhost/image.jpg');
+    }
+
+    public function test_it_limits_redirects()
+    {
+        $this->expectException(ConfigurationException::class);
+        $this->expectExceptionMessage(
+            'Too many redirects for a remote URL.'
+        );
+        config()->set('mediable.max_remote_url_redirects', 2);
+        new RemoteUrlAdapter('https://httpbin.org/redirect/3');
+    }
 }


### PR DESCRIPTION
protect against SSRF from allowed remote hosts redirecting to private IPs, non-whitelisted hosts, or other protocols